### PR TITLE
add data path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+data/*
+.vscode/settings.json
+notebooks/nlp/df_all.csv
+notebooks/nlp/df_X_tfidf.pkl
+.vscode/settings.json
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "test"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}


### PR DESCRIPTION
This is a way of letting the collaborators upload the data from the Drive in the data folder, but never pushing it to GitHub. It enables the project to stay self-contained. It's still a temporary fix waiting for the db, but it's guarding the github history and pushing/pulling against becoming huge in case of inattention.
 What do you think?