### PR TITLE
Feature/sitemap article time

### DIFF
--- a/pages/4_Exploration_Siteweb_Media.py
+++ b/pages/4_Exploration_Siteweb_Media.py
@@ -6,7 +6,9 @@ from streamlit_tags import st_tags
 
 from quotaclimat.data_analytics.sitemap_analytics import (
     fig_percentage_between_two_dates_per_day_and_leaderboard_per_media,
-    plot_comparison_of_temporal_total_count, plot_media_count_comparison,
+    plot_comparison_of_temporal_total_count, plot_articles_total_count_evolution,
+    plot_articles_lifespan_comparison,
+    plot_media_count_comparison,
     plot_media_count_comparison_all_kw)
 from quotaclimat.data_processing.sitemap_processing import (
     feature_engineering_sitemap, filter_df, load_all)
@@ -140,6 +142,16 @@ with tab2:
             df_between_two_dates, keywords, keywords_compare
         )
         st.plotly_chart(fig_temporal_count)
+
+        fig_temporal_total_count = plot_articles_total_count_evolution(
+            df_between_two_dates, keywords, keywords_compare
+        )
+        st.plotly_chart(fig_temporal_total_count)
+
+        fig_lifespan = plot_articles_lifespan_comparison(
+            df_between_two_dates, keywords, keywords_compare
+        )
+        st.plotly_chart(fig_lifespan)
 
 
 with tab3:

--- a/pages/4_Exploration_Siteweb_Media.py
+++ b/pages/4_Exploration_Siteweb_Media.py
@@ -6,9 +6,8 @@ from streamlit_tags import st_tags
 
 from quotaclimat.data_analytics.sitemap_analytics import (
     fig_percentage_between_two_dates_per_day_and_leaderboard_per_media,
-    plot_comparison_of_temporal_total_count, plot_articles_total_count_evolution,
-    plot_articles_lifespan_comparison,
-    plot_media_count_comparison,
+    plot_articles_lifespan_comparison, plot_articles_total_count_evolution,
+    plot_comparison_of_temporal_total_count, plot_media_count_comparison,
     plot_media_count_comparison_all_kw)
 from quotaclimat.data_processing.sitemap_processing import (
     feature_engineering_sitemap, filter_df, load_all)

--- a/quotaclimat/data_analytics/sitemap_analytics.py
+++ b/quotaclimat/data_analytics/sitemap_analytics.py
@@ -1,6 +1,8 @@
 import matplotlib.pyplot as plt
+import datetime as dt
 import nltk
 import pandas as pd
+import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
 from nltk.corpus import stopwords
@@ -96,7 +98,9 @@ def plot_media_count_comparison_all_kw(df, keywords: list):
 
 
 def plot_comparison_of_temporal_total_count(df, keywords: list, keywords_comp: list):
-
+    """
+    Comparaison de l évolution temporelle de l'apparition des mots clé
+    """
     df["news_publication_date_as_str"] = df.news_publication_date.dt.strftime(
         "%Y-%m-%d"
     )
@@ -142,6 +146,43 @@ def plot_comparison_of_temporal_total_count(df, keywords: list, keywords_comp: l
         xaxis_title="Date de publication des articles",
         yaxis_title="% du total d articles",
     )
+    return fig
+
+def plot_articles_total_count_evolution(df, keywords: list, keywords_comp: list):
+    """
+    Comparaison de l évolution temporelle de la présence des mots clé
+    """
+    duration = df["download_date_last"] - df["news_publication_date"] + dt.timedelta(days = 1)
+    df["duration_in_days"] = duration.dt.days
+
+    df_keywords_1 = df[df.news_title.str.contains("|".join(keywords))]
+    df_keywords_2 = df[df.news_title.str.contains("|".join(keywords_comp))]
+
+    label1 =  ", ".join(keywords)[:25] + "..."
+    label2 =  ", ".join(keywords_comp)[:25] + "..."
+    
+    day_min = df["news_publication_date"].dt.date.min()
+    day_max = df["download_date_last"].dt.date.max()
+    
+    article_count = pd.DataFrame(index = pd.date_range(day_min,day_max,freq='D'))
+    
+    for idx in article_count.index:
+        temp_min1 = df_keywords_1.news_publication_date.dt.date <= idx.date()
+        temp_max1  = idx.date() <= df_keywords_1.download_date_last.dt.date
+        article_count.loc[idx,label1] = sum(np.logical_and(temp_min1,temp_max1))
+        
+        temp_min2 = df_keywords_2.news_publication_date.dt.date <= idx.date()
+        temp_max2  = idx.date() <= df_keywords_2.download_date_last.dt.date
+        article_count.loc[idx,label2] = sum(np.logical_and(temp_min2,temp_max2))    
+    
+    
+    fig = px.line(
+        article_count.reset_index(),
+        x="index",
+        y = [label1,label2],
+        title="Evolution du nombre d'articles comprenant un mot d'une des deux listes au cours du temps",
+    )
+    
     return fig
 
 
@@ -241,3 +282,31 @@ def fig_percentage_between_two_dates_per_day_and_leaderboard_per_media(
         )
     )
     return figs_percentage
+
+
+def plot_articles_lifespan_comparison(df, keywords: list, keywords_comp: list):
+    
+    duration = df["download_date_last"] - df["news_publication_date"] + dt.timedelta(days = 1)
+    df["duration_in_days"] = duration.dt.days
+
+    df_keywords_1 = df[df.news_title.str.contains("|".join(keywords))]
+    df_keywords_2 = df[df.news_title.str.contains("|".join(keywords_comp))]
+
+    df_keywords_1["keyword list"] = ", ".join(keywords)[:25] + "..."
+    df_keywords_2["keyword list"] = ", ".join(keywords_comp)[:25] + "..."
+
+    df_to_plot = pd.concat([df_keywords_1, df_keywords_2])
+    
+    fig = px.box(
+        df_to_plot,
+        x="media",
+        y="duration_in_days",
+        color="keyword list",
+        title="Répartition du nombre de jours de présences des articles comprenant un mot d'une des deux listes",
+        hover_data = ["news_title"] ,
+        log_y = True
+    )
+    
+    return fig
+
+

--- a/quotaclimat/data_analytics/sitemap_analytics.py
+++ b/quotaclimat/data_analytics/sitemap_analytics.py
@@ -1,8 +1,9 @@
-import matplotlib.pyplot as plt
 import datetime as dt
+
+import matplotlib.pyplot as plt
 import nltk
-import pandas as pd
 import numpy as np
+import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from nltk.corpus import stopwords
@@ -148,41 +149,43 @@ def plot_comparison_of_temporal_total_count(df, keywords: list, keywords_comp: l
     )
     return fig
 
+
 def plot_articles_total_count_evolution(df, keywords: list, keywords_comp: list):
     """
     Comparaison de l évolution temporelle de la présence des mots clé
     """
-    duration = df["download_date_last"] - df["news_publication_date"] + dt.timedelta(days = 1)
+    duration = (
+        df["download_date_last"] - df["news_publication_date"] + dt.timedelta(days=1)
+    )
     df["duration_in_days"] = duration.dt.days
 
     df_keywords_1 = df[df.news_title.str.contains("|".join(keywords))]
     df_keywords_2 = df[df.news_title.str.contains("|".join(keywords_comp))]
 
-    label1 =  ", ".join(keywords)[:25] + "..."
-    label2 =  ", ".join(keywords_comp)[:25] + "..."
-    
+    label1 = ", ".join(keywords)[:25] + "..."
+    label2 = ", ".join(keywords_comp)[:25] + "..."
+
     day_min = df["news_publication_date"].dt.date.min()
     day_max = df["download_date_last"].dt.date.max()
-    
-    article_count = pd.DataFrame(index = pd.date_range(day_min,day_max,freq='D'))
-    
+
+    article_count = pd.DataFrame(index=pd.date_range(day_min, day_max, freq="D"))
+
     for idx in article_count.index:
         temp_min1 = df_keywords_1.news_publication_date.dt.date <= idx.date()
-        temp_max1  = idx.date() <= df_keywords_1.download_date_last.dt.date
-        article_count.loc[idx,label1] = sum(np.logical_and(temp_min1,temp_max1))
-        
+        temp_max1 = idx.date() <= df_keywords_1.download_date_last.dt.date
+        article_count.loc[idx, label1] = sum(np.logical_and(temp_min1, temp_max1))
+
         temp_min2 = df_keywords_2.news_publication_date.dt.date <= idx.date()
-        temp_max2  = idx.date() <= df_keywords_2.download_date_last.dt.date
-        article_count.loc[idx,label2] = sum(np.logical_and(temp_min2,temp_max2))    
-    
-    
+        temp_max2 = idx.date() <= df_keywords_2.download_date_last.dt.date
+        article_count.loc[idx, label2] = sum(np.logical_and(temp_min2, temp_max2))
+
     fig = px.line(
         article_count.reset_index(),
         x="index",
-        y = [label1,label2],
+        y=[label1, label2],
         title="Evolution du nombre d'articles comprenant un mot d'une des deux listes au cours du temps",
     )
-    
+
     return fig
 
 
@@ -285,8 +288,10 @@ def fig_percentage_between_two_dates_per_day_and_leaderboard_per_media(
 
 
 def plot_articles_lifespan_comparison(df, keywords: list, keywords_comp: list):
-    
-    duration = df["download_date_last"] - df["news_publication_date"] + dt.timedelta(days = 1)
+
+    duration = (
+        df["download_date_last"] - df["news_publication_date"] + dt.timedelta(days=1)
+    )
     df["duration_in_days"] = duration.dt.days
 
     df_keywords_1 = df[df.news_title.str.contains("|".join(keywords))]
@@ -296,17 +301,15 @@ def plot_articles_lifespan_comparison(df, keywords: list, keywords_comp: list):
     df_keywords_2["keyword list"] = ", ".join(keywords_comp)[:25] + "..."
 
     df_to_plot = pd.concat([df_keywords_1, df_keywords_2])
-    
+
     fig = px.box(
         df_to_plot,
         x="media",
         y="duration_in_days",
         color="keyword list",
         title="Répartition du nombre de jours de présences des articles comprenant un mot d'une des deux listes",
-        hover_data = ["news_title"] ,
-        log_y = True
+        hover_data=["news_title"],
+        log_y=True,
     )
-    
+
     return fig
-
-

--- a/quotaclimat/data_ingestion/scrap_youtube.py
+++ b/quotaclimat/data_ingestion/scrap_youtube.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
 import os
-import isodate
 
+import isodate
 import pandas as pd
 from apiclient.discovery import build
 from config_youtube import CHANNEL_CONFIG
@@ -10,6 +10,7 @@ from config_youtube import CHANNEL_CONFIG
 API_SERVICE_NAME = "youtube"
 API_VERSION = "v3"
 KEY = "AIzaSyDATQZwjAZ__AARZvLZRmAWpkcG0BQgKdM"  # Google account created: email:scrapping.job.api.key@gmail.com pwd:scrappingjob12345
+
 
 def create_youtube_object():
 
@@ -142,7 +143,9 @@ def video_formatting(videos_scraped: list) -> dict:
             video["channel"] = items[i]["snippet"]["channelTitle"]
             video["description"] = items[i]["snippet"]["description"]
             video["publication_date"] = items[i]["snippet"]["publishedAt"]
-            video['duration (s)'] = isodate.parse_duration(items[i]['contentDetails']['duration']).total_seconds()
+            video["duration (s)"] = isodate.parse_duration(
+                items[i]["contentDetails"]["duration"]
+            ).total_seconds()
             if "viewCount" in items[i]["statistics"]:
                 video["view_count"] = items[i]["statistics"]["viewCount"]
             else:

--- a/quotaclimat/data_processing/sitemap_processing.py
+++ b/quotaclimat/data_processing/sitemap_processing.py
@@ -16,6 +16,11 @@ def load_all(path: str = LANDING_PATH_SITEMAP):
     df = pd.concat(dfs)
     return filter_on_first_ingestion_date(df)
 
+def load_month(year: int, month: int, path: str = LANDING_PATH_SITEMAP):
+    files = glob.glob(path + f"**/**/year={year}\month={month}/*.parquet")
+    dfs = [pd.read_parquet(fp) for fp in files]
+    df = pd.concat(dfs)
+    return filter_on_first_ingestion_date(df)
 
 def load_tv():
     files = glob.glob(LANDING_PATH_SITEMAP + "media_type=tv/**/**/**/*.parquet")

--- a/quotaclimat/data_processing/sitemap_processing.py
+++ b/quotaclimat/data_processing/sitemap_processing.py
@@ -16,11 +16,13 @@ def load_all(path: str = LANDING_PATH_SITEMAP):
     df = pd.concat(dfs)
     return filter_on_first_ingestion_date(df)
 
+
 def load_month(year: int, month: int, path: str = LANDING_PATH_SITEMAP):
     files = glob.glob(path + f"**/**/year={year}\month={month}/*.parquet")
     dfs = [pd.read_parquet(fp) for fp in files]
     df = pd.concat(dfs)
     return filter_on_first_ingestion_date(df)
+
 
 def load_tv():
     files = glob.glob(LANDING_PATH_SITEMAP + "media_type=tv/**/**/**/*.parquet")


### PR DESCRIPTION
Deux plot ajoutés : 
- La durée de vie des articles par liste et par média
- Le nombre d'article de chacun des listes en cours (attention, le graphe précédent dans la page streamlit concerne les APPARITIONS d'article dans une liste, par le compte total (i.e. si des articles de la veille restent)

Je n'ai pas pu testé directement comme je n'ai pas réussi à faire fonctionner le poetry, mais les graphes tournent chez moi.

Bonus : une fonction pour ne charger qu'un mois en particulier, si on veut se limiter en mémoire plutôt que d'utiliser le load_all par défaut.