### PR TITLE
feat: add integration test at push

### DIFF
--- a/.github/workflows/check_integration.yml
+++ b/.github/workflows/check_integration.yml
@@ -1,0 +1,26 @@
+name: check_integration
+
+on:
+  push:
+
+env:
+  PYTHON_VERSION: '3.10'
+  POETRY_VERSION: '1.2.1'
+
+jobs:
+  check_integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/checkout@v2
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Verify poetry.lock agrees with pyproject.toml
+        run: poetry lock --check


### PR DESCRIPTION
This ensures the `.toml` is aligned with the `.lock` (so that the environment can be build when deploying). This is the first integration test. More can be added in the same/copy-pasted workflow.