### PR TITLE
Feat(data): add keyword with timestamp + improve keywords detection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 secrets/pwd_api.txt
 secrets/username_api.txt
+coverage_re
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     entrypoint: ["python", "quotaclimat/data_processing/mediatree/api_import.py"]
     environment:
       ENV: docker # change me to prod for real cases
-      LOGLEVEL: debug # Change me to info (debug, info, warning, error) to have less log
+      LOGLEVEL: INFO # Change me to info (debug, info, warning, error) to have less log
       PYTHONPATH: /app
       POSTGRES_USER: user
       POSTGRES_DB: barometre

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     entrypoint: ["python", "quotaclimat/data_processing/mediatree/api_import.py"]
     environment:
       ENV: docker # change me to prod for real cases
-      LOGLEVEL: INFO # Change me to info (debug, info, warning, error) to have less log
+      LOGLEVEL: debug # Change me to info (debug, info, warning, error) to have less log
       PYTHONPATH: /app
       POSTGRES_USER: user
       POSTGRES_DB: barometre

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,17 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    entrypoint: ["poetry", "run", "pytest", "-v", "--cov", "test", "test/"]
+    entrypoint: ["poetry", "run", "pytest", "-v", "--cov", "--cov-report=html:coverage_re", "test", "test/"]
     environment:
       ENV: docker
+      LOGLEVEL: DEBUG
       PYTHONPATH: /app
       POSTGRES_USER: user
       POSTGRES_DB: barometre
       POSTGRES_PASSWORD: password
       POSTGRES_HOST: postgres_db
       POSTGRES_PORT: 5432
+    tty: true # colorize terminal
     volumes:
       - ./quotaclimat/:/app/quotaclimat/
       - ./postgres/:/app/postgres/

--- a/postgres/insert_data.py
+++ b/postgres/insert_data.py
@@ -4,7 +4,7 @@ import time
 import pandas as pd
 from sqlalchemy import DateTime
 from sqlalchemy.dialects.postgresql import insert
-
+from sqlalchemy import JSON
 from postgres.schemas.models import sitemap_table
 
 def clean_data(df: pd.DataFrame):
@@ -40,7 +40,7 @@ def show_sitemaps_dataframe(df: pd.DataFrame):
             logging.warning("Could show sitemap before saving : \n %s \n %s" % (err, df.head(1).to_string()))
 
 def save_to_pg(df, table, conn):
-    logging.info(f"Saving to PG table {table}")
+    logging.info(f"Saving to PG table '{table}'")
     logging.debug("Saving %s" % (df.head(1).to_string()))
     try:
         logging.debug("Schema before saving\n%s", df.dtypes)
@@ -51,6 +51,7 @@ def save_to_pg(df, table, conn):
             if_exists="append",
             chunksize=1000,
             method=insert_or_do_nothing_on_conflict,  # pandas does not handle conflict natively
+            dtype={"keywords_with_timestamp": JSON}, # only for keywords
         )
         logging.info("Saved dataframe to PG")
         return len(df)

--- a/postgres/schemas/models.py
+++ b/postgres/schemas/models.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, String, Text, Boolean, ARRAY, JSON
+from sqlalchemy import Column, DateTime, String, Text, Boolean, ARRAY, JSON, Integer
 from sqlalchemy.orm import declarative_base
 import pandas as pd
 from sqlalchemy import text
@@ -59,6 +59,7 @@ class Keywords(Base):
     theme=Column(ARRAY(String)) #keyword.py
     created_at = Column(DateTime(timezone=True), server_default=text("(now() at time zone 'utc')"))
     keywords_with_timestamp = Column(JSON)
+    number_of_keywords = Column(Integer)
 
 
 def get_sitemap(id: str):

--- a/postgres/schemas/models.py
+++ b/postgres/schemas/models.py
@@ -65,6 +65,10 @@ def get_sitemap(id: str):
     session = get_db_session()
     return session.get(Sitemap, id)
 
+def get_keyword(id: str):
+    session = get_db_session()
+    return session.get(Keywords, id)
+
 def get_last_month_sitemap_id(engine): 
     query = text("""
     SELECT id 

--- a/quotaclimat/data_ingestion/scrap_homepage_lemonde/scrap_homepage.py
+++ b/quotaclimat/data_ingestion/scrap_homepage_lemonde/scrap_homepage.py
@@ -150,7 +150,7 @@ def get_type_home(df):
 def created_at_column(df: pd.DataFrame) -> pd.DataFrame:
     """Create new colomn with datetime now from Paris"""
 
-    df["created_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    df["created_at"] = .now().strftime("%Y-%m-%d %H:%M:%S")
     df["created_at"] = df["created_at"].apply(pd.Timestamp)
 
     return df

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -100,7 +100,8 @@ def get_cts_in_ms_for_keywords(subtitle_duration: List[dict], keywords: List[str
     logging.debug(f"Looking for timecode for {keywords}")
     for multiple_keyword in keywords:
         all_keywords = multiple_keyword.split() # case with multiple words such as 'économie circulaire'
-        match = next((item for item in subtitle_duration if item.get('text') == all_keywords[0]), None)       
+        match = next((item for item in subtitle_duration if item.get('text').lower() == all_keywords[0].lower()), None)  
+        logging.debug(f"match found {match} with {all_keywords[0].lower()}")     
         if match is not None:
             logging.debug(f'Result added due to this match {match} based on {all_keywords[0]}')
             result.append({multiple_keyword: match['cts_in_ms']})
@@ -114,7 +115,7 @@ def get_themes_keywords_duration(plaintext: str, subtitle_duration: List[str]) -
 
     for theme, keywords in THEME_KEYWORDS.items():
         logging.debug(f"searching {theme} for {keywords}")
-        matching_words = [word for word in keywords if word in plaintext]
+        matching_words = [word for word in keywords if word.lower() in plaintext.lower()]
         if matching_words:
             logging.info(f"theme found : {theme} with word {matching_words}")
             matching_themes.append(theme)

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -97,12 +97,15 @@ def transform_theme_query_includes(themes_with_keywords = THEME_KEYWORDS):
 def get_cts_in_ms_for_keywords(subtitle_duration: List[dict], keywords: List[str]) -> List[dict]:
     result = []
 
+    logging.debug(f"Looking for timecode for {keywords}")
     for multiple_keyword in keywords:
         all_keywords = multiple_keyword.split() # case with multiple words such as 'économie circulaire'
-        match = next((item for item in subtitle_duration if item.get('text') == all_keywords[0]), None)
+        match = next((item for item in subtitle_duration if item.get('text') == all_keywords[0]), None)       
         if match is not None:
+            logging.debug(f'Result added due to this match {match} based on {all_keywords[0]}')
             result.append({multiple_keyword: match['cts_in_ms']})
 
+    logging.debug(f"Timecode found {result}")
     return result
 
 def get_themes_keywords_duration(plaintext: str, subtitle_duration: List[str]) -> List[Optional[List[str]]]:
@@ -116,7 +119,7 @@ def get_themes_keywords_duration(plaintext: str, subtitle_duration: List[str]) -
             logging.info(f"theme found : {theme} with word {matching_words}")
             matching_themes.append(theme)
             # look for cts_in_ms inside matching_words (['économie circulaire', 'panneaux solaires', 'solaires'] from subtitle_duration 
-            keywords_with_timestamp = get_cts_in_ms_for_keywords(subtitle_duration, matching_words)
+            keywords_with_timestamp.extend(get_cts_in_ms_for_keywords(subtitle_duration, matching_words))
     
     if len(matching_themes) > 0:
         return [matching_themes, keywords_with_timestamp]

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -147,19 +147,19 @@ def get_themes_keywords_duration(plaintext: str, subtitle_duration: List[str]) -
             matching_themes.append(theme)
             # look for cts_in_ms inside matching_words (['économie circulaire', 'panneaux solaires', 'solaires'] from subtitle_duration 
             keywords_to_add = get_cts_in_ms_for_keywords(subtitle_duration, matching_words, theme)
-            number_of_keywords = len(keywords_to_add)
-            if(number_of_keywords == 0):
+            if(len(keywords_to_add) == 0):
                 logging.warning(f"Check regex - Empty keywords but themes is there {theme} - matching_words {matching_words} - {subtitle_duration}")
             keywords_with_timestamp.extend(keywords_to_add)
     
     if len(matching_themes) > 0:
-        return [matching_themes, keywords_with_timestamp]
+        return [matching_themes, keywords_with_timestamp, int(len(keywords_with_timestamp))]
     else:
-        return [None, None]
+        return [None, None, None]
+
 def filter_and_tag_by_theme(df: pd.DataFrame) -> pd.DataFrame :
     count_before_filtering = len(df)
     logging.info(f"{count_before_filtering} subtitles to filter by keywords and tag with themes")
-    df[['theme', u'keywords_with_timestamp']] = df[['plaintext','srt']].apply(lambda row: get_themes_keywords_duration(*row), axis=1, result_type='expand')
+    df[['theme', u'keywords_with_timestamp', 'number_of_keywords']] = df[['plaintext','srt']].apply(lambda row: get_themes_keywords_duration(*row), axis=1, result_type='expand')
 
     # remove all rows that does not have themes
     df = df.dropna(subset=['theme'])

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -19,6 +19,7 @@ from pandas import json_normalize
 from quotaclimat.data_processing.mediatree.keyword.keyword import THEME_KEYWORDS
 from typing import List, Optional
 from quotaclimat.data_ingestion.scrap_sitemap import get_consistent_hash
+import re
 
 #read whole file to a string
 password = os.environ.get("MEDIATREE_PASSWORD")
@@ -34,10 +35,14 @@ async def get_and_save_api_data(exit_event):
     conn = connect_to_db()
     token=get_auth_token(password=password, user_name=USER)
 
-    channels = ["tf1", "france2", "m6", "arte", "d8", "tmc", "bfmtv", "lci", "franceinfotv", "itele",
-     "europe1", "france-culture", "france-inter", "nrj", "rfm", "rmc", "rtl", "rtl2"]
-    #channels = ["arte"]
+    if(os.environ.get("ENV") == "docker"):
+        logging.warning("Docker cases - only some channels are used")
+        channels = ["tf1", "france2"]
+    else: #prod    
+        channels = ["tf1", "france2", "m6", "arte", "d8", "tmc", "bfmtv", "lci", "franceinfotv", "itele",
+        "europe1", "france-culture", "france-inter", "nrj", "rfm", "rmc", "rtl", "rtl2"]
 
+    logging.info(f"Importing {channels}")
     for channel in channels :
         try:
             df = extract_api_sub(token, channel)
@@ -94,19 +99,40 @@ def get_cts_in_ms_for_keywords(subtitle_duration: List[dict], keywords: List[str
     logging.debug(f"Looking for timecode for {keywords}")
     for multiple_keyword in keywords:
         all_keywords = multiple_keyword.split() # case with multiple words such as 'économie circulaire'
-        match = next((item for item in subtitle_duration if item.get('text').lower() == all_keywords[0].lower()), None)  
+        match = next((item for item in subtitle_duration if is_word_in_sentence(all_keywords[0], item.get('text'))), None)  
         logging.debug(f"match found {match} with {all_keywords[0].lower()}")     
         if match is not None:
             logging.debug(f'Result added due to this match {match} based on {all_keywords[0]}')
             result.append(
                 {
-                    "keyword" :multiple_keyword,
-                    "timestamp" : match['cts_in_ms'], # TODO is it a real timestamp for PG ?
+                    "keyword" :multiple_keyword.lower(),
+                    "timestamp" : match['cts_in_ms'],
                     "theme" : theme
                 })
 
     logging.debug(f"Timecode found {result}")
     return result
+
+# be able to detect singular or plural for a word
+def format_word_regex(word: str) -> str:
+    word = word.replace('\'', '\' ?') # case for d'eau -> d' eau
+    if not word.endswith('s') and not word.endswith('x') and not word.endswith('à'):
+        return word + "s?"
+    elif word.endswith('s'):
+        return word + '?'
+    else:
+        return word
+
+def is_word_in_sentence(words: str, sentence: str) -> bool :
+    # words can contain plurals and several words
+    words = ' '.join(list(map(( lambda x: format_word_regex(x)), words.split(" "))))
+    logging.debug(f"testing {words}")
+    #  test https://regex101.com/r/ilvs9G/1/
+    if re.search(rf"\b{words}(?![\w-])", sentence, re.IGNORECASE):
+        logging.debug(f"words {words} found in {sentence}")
+        return True
+    else:
+        return False
 
 def get_themes_keywords_duration(plaintext: str, subtitle_duration: List[str]) -> List[Optional[List[str]]]:
     matching_themes = []
@@ -114,30 +140,33 @@ def get_themes_keywords_duration(plaintext: str, subtitle_duration: List[str]) -
 
     for theme, keywords in THEME_KEYWORDS.items():
         logging.debug(f"searching {theme} for {keywords}")
-        matching_words = [word for word in keywords if word.lower() in plaintext.lower()]
+
+        matching_words = [word for word in keywords if is_word_in_sentence(word, plaintext)]  
         if matching_words:
-            logging.info(f"theme found : {theme} with word {matching_words}")
+            logging.debug(f"theme found : {theme} with word {matching_words}")
             matching_themes.append(theme)
             # look for cts_in_ms inside matching_words (['économie circulaire', 'panneaux solaires', 'solaires'] from subtitle_duration 
-            keywords_with_timestamp.extend(get_cts_in_ms_for_keywords(subtitle_duration, matching_words, theme))
+            keywords_to_add = get_cts_in_ms_for_keywords(subtitle_duration, matching_words, theme)
+            number_of_keywords = len(keywords_to_add)
+            if(number_of_keywords == 0):
+                logging.warning(f"Check regex - Empty keywords but themes is there {theme} - matching_words {matching_words} - {subtitle_duration}")
+            keywords_with_timestamp.extend(keywords_to_add)
     
     if len(matching_themes) > 0:
         return [matching_themes, keywords_with_timestamp]
     else:
         return [None, None]
 def filter_and_tag_by_theme(df: pd.DataFrame) -> pd.DataFrame :
-    logging.info(f"{len(df)} subtitles to filter by keywords and tag with themes")
-    df[['theme', 'keywords_with_timestamp']] = df[['plaintext','srt']].apply(lambda row: get_themes_keywords_duration(*row), axis=1, result_type='expand')
+    count_before_filtering = len(df)
+    logging.info(f"{count_before_filtering} subtitles to filter by keywords and tag with themes")
+    df[['theme', u'keywords_with_timestamp']] = df[['plaintext','srt']].apply(lambda row: get_themes_keywords_duration(*row), axis=1, result_type='expand')
 
     # remove all rows that does not have themes
     df = df.dropna(subset=['theme'])
 
     df.drop('srt', axis=1, inplace=True)
 
-    # format for PG
-    df['keywords_with_timestamp'].apply(json.dumps)
-
-    logging.info(f"After filtering, we have {len(df)} subtitles left")
+    logging.info(f"After filtering with out keywords, we have {len(df)} out of {count_before_filtering} subtitles left that are insteresting for us")
     return df
 
 def add_primary_key(df):

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -88,12 +88,6 @@ def get_theme_query_includes(theme_dict):
 def transform_theme_query_includes(themes_with_keywords = THEME_KEYWORDS):
     return list(map(get_theme_query_includes, themes_with_keywords))
 
-# keywords : (['économie circulaire', 'panneaux solaires', 'solaires']
-# subtitle_duration : {
-        #   "duration_ms": 34,
-        #   "cts_in_ms": 1706437079004,
-        #   "text": "gilets"
-        # }
 def get_cts_in_ms_for_keywords(subtitle_duration: List[dict], keywords: List[str]) -> List[dict]:
     result = []
 

--- a/quotaclimat/data_processing/mediatree/keyword/keyword.py
+++ b/quotaclimat/data_processing/mediatree/keyword/keyword.py
@@ -7,7 +7,7 @@ THEME_KEYWORDS = {
             ,"écologique", "écologiste"
             ,"anthropocène"
             ,"cycle du carbone", "effet de serre", "neutralité carbone", "neutralité climatique", "croissance verte", "décarbonation"
-            ,"protection de la planète", "habitabilité de la planète", "conditions de vie sur Terre"
+            ,"protection de la planète", "habitabilité de la planète", "conditions de vie sur terre"
             ,"soutenabilité environnementale"
             ,"développement durable"
             ,"dépolluer"
@@ -15,7 +15,7 @@ THEME_KEYWORDS = {
             ,"crise planétaire"
             ,"accord de paris", "accords de paris","COP21", "COP15", "COP26", "COP27", "COP28", "COP29", "COP30"
             ,"Conférence des Parties", "conférence climat", "conférence des Nations Unies sur le climat"
-            ,"GIEC", "Haut conseil pour le climat", "convention des Nations unies sur le climat"
+            ,"GIEC", "Haut conseil pour le climat", "convention des nations unies sur le climat"
             ,"transition agricole", "transition énergétique"
         ]
 ,
@@ -171,7 +171,7 @@ THEME_KEYWORDS = {
 "ressources_naturelles_concepts_generaux": # 1.2.1
 [
 "crise environnementale", "crise climatique", "crise écologique", "écologie", "écologique", "environnement", "environnemental"
-,"anthropocène", "limites planétaires", "planète", "dépassement des limites planétaires", "épuisement des ressources", "jour du dépassement"
+,"anthropocène", "limites planétaires", "dépassement des limites planétaires", "épuisement des ressources", "jour du dépassement"
 ,"raréfaction de l’eau", "pénurie d’eau", "disponibilité d’eau douce", "baisse de la qualité de l’eau", "cycle de l’eau"
 ,"salinisation des nappes", "nappes phréatiques", "pollution de l’eau", "pollution des nappes phréatiques"
 ,"sécheresse", "augmentation des risques de sécheresse", "stress hydrique", "canicule", "déficite de pluie"

--- a/quotaclimat/data_processing/mediatree/keyword/keyword.py
+++ b/quotaclimat/data_processing/mediatree/keyword/keyword.py
@@ -13,7 +13,7 @@ THEME_KEYWORDS = {
             ,"dépolluer"
             ,"protection du vivant", "protection des océans"
             ,"crise planétaire"
-            ,"accord de paris", "accords de paris","COP21", "COP15", "COP26", "COP27", "COP28", "COP29", "COP30"
+            ,"accord de paris","COP21", "COP15", "COP26", "COP27", "COP28", "COP29", "COP30"
             ,"Conférence des Parties", "conférence climat", "conférence des Nations Unies sur le climat"
             ,"GIEC", "Haut conseil pour le climat", "convention des nations unies sur le climat"
             ,"transition agricole", "transition énergétique"
@@ -35,9 +35,9 @@ THEME_KEYWORDS = {
     "vache", "élevage", "élevage bovin"
     ,"viande",
     "malbouffe"
-    ,"agricole", "agriculture", "agriculteurs",
+    ,"agricole", "agriculture", "agriculteur",
     "bâtiment", "Chauffage",
-    "transport", "automobile", "voitures", "aviation", "SUV",
+    "transport", "automobile", "voiture", "aviation", "SUV",
     "industrie", "secteur tertiaire",
     "énergie", "énergétique",
     "déchets",
@@ -54,13 +54,13 @@ THEME_KEYWORDS = {
 ],
 "changement_climatique_consequences" : [ # 1.1.3
     "augmentation des températures", "hausse de la température du globe", "température moyenne de surface", "élévation des températures",
-    "météorologiques extrêmes", "phénomènes climatiques extrêmes",
+    "météorologique extrême", "phénomène climatique extrêmes",
     "période la plus chaude", "année la plus chaude", "mois le plus chaud", "jour le plus chaud",
-    "pénuries",
+    "pénurie",
     "record de température",
     "élévation du niveau de la mer", "hausse du niveau de la mer", "montée du niveau de la mer", "hausse du niveau marin", "élévation du niveau marin", "montée du niveau marin", "hausse du niveau des océans", "élévation du niveau des océans", "montée du niveau des océans",
     "fonte des glaces", "fonte des glaciers", "fonte de la banquise", "diminution de la banquise", "diminution des glaciers", "disparition des glaciers", "fonte des calottes glacières", "fonte du permafrost",
-    "érosion côtières", "érosion des côtes", "inondations", "submersion", "submersions marines", "submersion", "crues centennales",
+    "érosion côtière", "érosion des côtes", "inondations", "submersion", "submersions marines", "crues centennales",
     "blanchissement des coraux", "disparition des coraux",
     "sécheresse", "augmentation des risques de sécheresse", "stress hydrique", "canicule", "déficit de pluie", "pénurie de neige",
     "raréfaction de la ressource en eau", "rareté de la ressource en eau", "restrictions d’eau", "manquer d’eau",
@@ -79,7 +79,7 @@ THEME_KEYWORDS = {
     "migrations climatiques", "migrants climatiques",
     "prolifération de moustiques", "moustique tigre", "chenille processionnaire",
     "zoonose",
-    "espèces invasives",
+    "espèce invasive",
     "retrait gonflement des argiles"
 ],
 "atténuation_climatique_solutions_directes" : [ # 1.1.4.1
@@ -92,11 +92,11 @@ THEME_KEYWORDS = {
     ,"atténuation du changement climatique"
     ,"alternative durable", "moins polluant"
     ,"économie circulaire"
-    ,"mobilité durable", "Voitures électriques", "Covoiturage", "Biocarburants"
+    ,"mobilité durable", "Voiture électrique", "Covoiturage", "Biocarburant"
     ,"écoconception"
     ,"réseaux de chaleur", "énergies renouvelables", "transition énergétique", "électricité décarboné", "énergies vertes",
-    "énergies durables", "éolien", "panneaux solaires", "solaires", "photovoltaïque", "géothermie", "hydroélectricité",
-    "barrages", "centrales hydroélectriques", "biomasse", "méthaniseur", "méthanisation", "biogaz", "bois-énergie", 
+    "énergiesdurable", "éolien", "panneaux solaires", "solaires", "photovoltaïque", "géothermie", "hydroélectricité",
+    "barrage", "centrale hydroélectrique", "biomasse", "méthaniseur", "méthanisation", "biogaz", "bois-énergie", 
     "nucléaire", "réacteurs nucléaires", "EPR", "hydrogène vert"
     ,"économies d’énergie", "lutte contre les gaspillages énergétiques", "réduction des gaspillages énergétique", "efficacité énergétique", "économiser de l’énergie",
      "sobriété énergétique"
@@ -124,7 +124,7 @@ THEME_KEYWORDS = {
     ,"transport maritime"
     ,"transports collectifs", "transports en commun", "bus électrique", "bus"
     ,"bois d’oeuvre"
-    ,"isolation", "isolation thermique", "pompes à chaleur (SAUF groupe verlaine", "SAUF atlantique)", "changement de chaudière"
+    ,"isolation", "isolation thermique", "pompes à chaleur", "changement de chaudière"
     , "chaudière biomasse"
     ,"matériaux biosourcés", "matériaux recyclés", "matériaux recyclables"
     ,"forêts"
@@ -162,8 +162,8 @@ THEME_KEYWORDS = {
 ],
 "adaptation_climatique_solutions_indirectes": # 1.1.5.2
 [
-    "digues" 
-    ,"dunes" 
+    "digue" 
+    ,"dune" 
     ,"gestion des milieux aquatiques"
     ,"sorgho"
     ,"myscanthus" 
@@ -194,7 +194,7 @@ THEME_KEYWORDS = {
 [
     "analyse de cycle de vie", "ACV"
     ,"biomimétisme", "bioinspiration"
-    ,"sobriété", "réduction de la demande", "réduction de la consommation (de ressources)", "maîtrise de la demande", "modération de la consommation"
+    ,"sobriété", "réduction de la demande", "réduction de la consommation", "maîtrise de la demande", "modération de la consommation"
     , "fin de l’abondance"
     ,"efficience énergétique", "efficacité énergétique"
     ,"décarbonation", "captage du carbone"
@@ -216,14 +216,14 @@ THEME_KEYWORDS = {
     ,"conservation de la nature", "conserver la nature", "protéger la nature"
     ," protection de la nature", "protéger le vivant", "protection du vivant"
     ,"la composition physique et biologique de"
-    ,"ecosystèmes", "écosystémique", "services écosystémiques", "restauration des écosystèmes", "processus écosystémiques", "résilience des écosystèmes"
-    , "écosystèmes dégradés", "dégradation des écosystèmes", "contribution de la nature"
+    ,"ecosystème", "écosystémique", "services écosystémiques", "restauration des écosystèmes", "processus écosystémiques", "résilience des écosystèmes"
+    , "écosystème dégradé", "dégradation des écosystèmes", "contribution de la nature"
     ,"IPBES"
     ,"fertilité des sols", "pollinisation"
     ,"intégrité écologique"
     ,"interactions entre les êtres vivants"
     ,"corail", "coraux", "récifs coralliens"
-    ,"convention des Nations unies sur la diversité biologique (CDB)", "COP biodiversité", "COP de Montréal"
+    ,"convention des Nations unies sur la diversité biologique", "COP biodiversité", "COP de Montréal"
 ],
 "biodiversité_causes": # 1.3.2
 [ 
@@ -247,7 +247,7 @@ THEME_KEYWORDS = {
 ],
 "biodiversité_conséquences": # 1.3.3
 [
-    "espèces menacées", "espèces menacées d’extinction", "Extinction", "crise d'extinction de masse", "en voie de disparition", "Liste rouge de l'UICN"
+    "espèce menacée", "espèce menacée d’extinction", "Extinction", "crise d'extinction de masse", "en voie de disparition", "Liste rouge de l'UICN"
     , "liste rouge des espèces menacées", "disparition des oiseaux", "disparition des insectes"
     ,"migration des espèces"
     ,"désertification"

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -6,7 +6,10 @@ from utils import get_localhost, debug_df
 from quotaclimat.data_processing.mediatree.api_import import get_themes_keywords_duration, get_cts_in_ms_for_keywords, filter_and_tag_by_theme, parse_reponse_subtitle, get_includes_or_query, transform_theme_query_includes
 import json 
 from quotaclimat.data_processing.mediatree.keyword.keyword import THEME_KEYWORDS
+from postgres.schemas.models import drop_tables
 localhost = get_localhost()
+
+drop_tables()
 
 plaintext1="test1"
 plaintext2="test2"
@@ -191,11 +194,20 @@ def test_get_cts_in_ms_for_keywords():
         }
     ]
     keywords = ['économie circulaire', 'panneaux solaires', 'solaires']
+    theme = "changement_climatique_constat"
     expected = [
-         {'économie circulaire' : 1706437079072},
-         {'solaires':1706437080006},
+        {
+            "keyword":'économie circulaire',
+            "timestamp" : 1706437079072,
+            "theme": theme
+        },
+        {
+            "keyword":'solaires',
+            "timestamp" : 1706437080006,
+            "theme": theme
+        },
     ]
-    assert get_cts_in_ms_for_keywords(str, keywords) == expected
+    assert get_cts_in_ms_for_keywords(str, keywords, theme) == expected
 
 
 def test_filter_and_tag_by_theme():
@@ -308,7 +320,12 @@ def test_lower_case_filter_and_tag_by_theme():
             "changement_climatique_causes_indirectes",
             "ressources_naturelles_concepts_generaux"
         ],
-        "keywords_with_timestamp": [{'vache': 111}]
+        "keywords_with_timestamp": [
+            {
+                "keyword" :"vache",
+                "timestamp": 111,
+                "theme": "changement_climatique_causes_indirectes",
+        }]
     }])
 
     # List of words to filter on
@@ -383,11 +400,26 @@ def test_complexe_filter_and_tag_by_theme():
             "changement_climatique_constat",
             "ressources_naturelles_concepts_generaux",
         ],
-        "keywords_with_timestamp": [
-            {'habitabilité de la planète': 1706437079006},
-            {'conditions de vie sur terre': 1706437079010},
-            {'planète': 1706437079009},
-            {'terre': 1706437079011}
+        "keywords_with_timestamp": [{
+                "keyword" : 'habitabilité de la planète',
+                "timestamp": 1706437079006,
+                "theme":"changement_climatique_constat",
+            },
+            {
+                "keyword" : 'conditions de vie sur terre',
+                "timestamp": 1706437079010,
+                "theme":"changement_climatique_constat",
+            },
+            {
+                "keyword" : 'planète',
+                "timestamp": 1706437079009,
+                "theme":"ressources_naturelles_concepts_generaux",
+            },
+            {
+                "keyword" : 'terre',
+                "timestamp": 1706437079011,
+                "theme":"ressources_naturelles_concepts_generaux",
+            }
         ]
     }])
 

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -4,7 +4,7 @@ from quotaclimat.data_ingestion.scrap_html.scrap_description_article import get_
 from quotaclimat.data_ingestion.scrap_sitemap import get_description_article
 from bs4 import BeautifulSoup
 from utils import get_localhost, debug_df
-from quotaclimat.data_processing.mediatree.api_import import find_themes, filter_and_tag_by_theme, parse_reponse_subtitle, get_includes_or_query, transform_theme_query_includes
+from quotaclimat.data_processing.mediatree.api_import import find_themes, add_srt_keyword, filter_and_tag_by_theme, parse_reponse_subtitle, get_includes_or_query, transform_theme_query_includes
 import json 
 from quotaclimat.data_processing.mediatree.keyword.keyword import THEME_KEYWORDS
 localhost = get_localhost()
@@ -15,16 +15,45 @@ json_response = json.loads("""
 {"total_results":214,
 "number_pages":43,
 "data":[
-    {"channel":{"name":"m6","title":"M6","radio":false},"start":1704798000,
-        "plaintext":"test1"},
-    {"channel":{"name":"tf1","title":"M6","radio":false},"start":1704798120,
-        "plaintext":"test2"}
-],
-"elapsed_time_ms":335}
+        {
+            "srt": [{
+                "duration_ms": 34,
+                "cts_in_ms": 1706437079004,
+                "text": "gilets"
+                },
+                {
+                "duration_ms": 34,
+                "cts_in_ms": 1706437079038,
+                "text": "jaunes"
+                },
+                {
+                "duration_ms": 34,
+                "cts_in_ms": 1706437079072,
+                "text": "en"
+                },
+                {
+                "duration_ms": 34,
+                "cts_in_ms": 1706437080006,
+                "text": "france"
+                }
+            ],
+            "channel":{"name":"m6","title":"M6","radio":false},"start":1704798000,
+            "plaintext":"test1"
+        },
+        {
+            "srt": [{
+                "duration_ms": 34,
+                "cts_in_ms": 1706437079004,
+                "text": "adaptation"
+                }
+            ],
+            "channel":{"name":"tf1","title":"M6","radio":false},"start":1704798120,
+            "plaintext":"test2"}
+    ],
+    "elapsed_time_ms":335}
 """)
 
 def test_parse_reponse_subtitle():
-    theme = "test_theme"
     expected_result = pd.DataFrame([{
         "plaintext" : plaintext1,
         "channel_name" : "m6",
@@ -66,6 +95,7 @@ def test_transform_theme_query_includes():
 
     assert output == expected
 
+
 def test_find_themes():
     plaintext_nothing = "cheese pizza"
     assert find_themes(plaintext_nothing) == None
@@ -79,6 +109,31 @@ def test_find_themes():
      ,"changement_climatique_consequences"
      ,"adaptation_climatique_solutions_directes"
     ]
+
+def test_add_srt_keyword():
+    str = [{
+          "duration_ms": 34,
+          "cts_in_ms": 1706437079004,
+          "text": "gilets"
+        },
+        {
+          "duration_ms": 34,
+          "cts_in_ms": 1706437079038,
+          "text": "jaunes"
+        },
+        {
+          "duration_ms": 34,
+          "cts_in_ms": 1706437079072,
+          "text": "en"
+        },
+        {
+          "duration_ms": 34,
+          "cts_in_ms": 1706437080006,
+          "text": "france"
+        }
+    ]
+
+    assert add_srt_keyword(str) == None
 
 def test_filter():
     df1 = pd.DataFrame([{

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -283,6 +283,39 @@ def test_filter_and_tag_by_theme():
     debug_df(df)
     pd.testing.assert_frame_equal(df.reset_index(drop=True), expected_result.reset_index(drop=True))
 
+
+def test_lower_case_filter_and_tag_by_theme():
+    df1 = pd.DataFrame([{
+            "start": 1704798000,
+            "plaintext": "VACHE BOVIN Anthropocène",
+            "channel_name": "m6",
+            "channel_radio": False,
+            "srt": [{
+                "duration_ms": 34,
+                "cts_in_ms": 111,
+                "text": "Vache"
+                }
+            ],
+    }])
+
+    expected_result = pd.DataFrame([{
+        "start": 1704798000,
+        "plaintext":  "VACHE BOVIN Anthropocène",
+        "channel_name": "m6",
+        "channel_radio": False,
+        "theme": [
+            "changement_climatique_constat",
+            "changement_climatique_causes_indirectes",
+            "ressources_naturelles_concepts_generaux"
+        ],
+        "keywords_with_timestamp": [{'vache': 111}]
+    }])
+
+    # List of words to filter on
+    df = filter_and_tag_by_theme(df1)
+    debug_df(df)
+    pd.testing.assert_frame_equal(df.reset_index(drop=True), expected_result.reset_index(drop=True))
+
 def test_complexe_filter_and_tag_by_theme():
     df1 = pd.DataFrame([{
         "start": 1704798000,

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -163,26 +163,26 @@ def test_get_themes_keywords_duration():
     ]
 
     plaintext_nothing = "cheese pizza"
-    assert get_themes_keywords_duration(plaintext_nothing, subtitles) == [None,None]
+    assert get_themes_keywords_duration(plaintext_nothing, subtitles) == [None,None, None]
     plaintext_climat = "climatique test"
-    assert get_themes_keywords_duration(plaintext_climat, subtitles) == [["changement_climatique_constat"],[]]
+    assert get_themes_keywords_duration(plaintext_climat, subtitles) == [["changement_climatique_constat"],[], 0]
     plaintext_multiple_themes = "climatique test bovin migrations climatiques"
-    assert get_themes_keywords_duration(plaintext_multiple_themes, subtitles) == [["changement_climatique_constat", "changement_climatique_consequences"],[]]
+    assert get_themes_keywords_duration(plaintext_multiple_themes, subtitles) == [["changement_climatique_constat", "changement_climatique_consequences"],[], 0]
 
     # should not accept theme 'bus' for keyword "abusive"
     plaintext_regression_incomplete_word = "abusive"
-    assert get_themes_keywords_duration(plaintext_regression_incomplete_word, subtitles) == [None, None]
+    assert get_themes_keywords_duration(plaintext_regression_incomplete_word, subtitles) == [None,None, None]
     
     # should not accept theme 'ngt' for keyword "vingt"
     plaintext_regression_incomplete_word_ngt = "vingt"
-    assert get_themes_keywords_duration(plaintext_regression_incomplete_word_ngt, subtitles) == [None, None]
+    assert get_themes_keywords_duration(plaintext_regression_incomplete_word_ngt, subtitles) == [None,None, None]
     
 
     assert get_themes_keywords_duration("record de température pizza adaptation au dérèglement climatique", subtitles) == [[
       "changement_climatique_constat"
      ,"changement_climatique_consequences"
      ,"adaptation_climatique_solutions_directes"
-    ],[]]
+    ],[], 0]
 
 def test_get_cts_in_ms_for_keywords():
     str = [{
@@ -317,7 +317,8 @@ def test_filter_and_tag_by_theme():
             "changement_climatique_causes_indirectes",
             "ressources_naturelles_concepts_generaux"
         ],
-        "keywords_with_timestamp": []
+        "keywords_with_timestamp": [],
+        "number_of_keywords": 0.0
     },
     {
         "start": 1704798000,
@@ -325,7 +326,8 @@ def test_filter_and_tag_by_theme():
         "channel_name": "m6",
         "channel_radio": False,
         "theme": ["changement_climatique_consequences"],
-        "keywords_with_timestamp": []
+        "keywords_with_timestamp": [],
+        "number_of_keywords": 0.0
     }])
 
     # List of words to filter on
@@ -364,6 +366,7 @@ def test_lower_case_filter_and_tag_by_theme():
                 "timestamp": 111,
                 "theme": "changement_climatique_causes_indirectes",
         }]
+        ,"number_of_keywords": 1
     }])
 
     # List of words to filter on
@@ -401,6 +404,7 @@ def test_singular_plural_case_filter_and_tag_by_theme():
                 "timestamp": 111,
                 "theme": "changement_climatique_causes_indirectes",
         }]
+        ,"number_of_keywords": 1
     }])
 
     # List of words to filter on
@@ -496,6 +500,7 @@ def test_complexe_filter_and_tag_by_theme():
                 "theme":"ressources_naturelles_concepts_generaux",
             }
         ]
+        ,"number_of_keywords": 4
     }])
 
     # List of words to filter on
@@ -534,12 +539,13 @@ def test_save_to_pg_keyword():
     channel_name = "m6"
     df = pd.DataFrame([{
         "id" : primary_key,
-        "start": 1706437079006, #TODO timestamp
+        "start": 1706437079006,
         "plaintext": "cheese pizza habitabilité de la planète conditions de vie sur terre animal",
         "channel_name": channel_name,
         "channel_radio": False,
         "theme": themes,
         "keywords_with_timestamp": keywords_with_timestamp
+        ,"number_of_keywords": 4
     }])
 
     df['start'] = pd.to_datetime(df['start'], unit='ms').dt.tz_localize('UTC').dt.tz_convert('Europe/Paris')
@@ -554,6 +560,7 @@ def test_save_to_pg_keyword():
     assert result.channel_radio == False
     assert result.theme == themes 
     assert result.keywords_with_timestamp == keywords_with_timestamp
+    assert result.number_of_keywords == 4
     assert result.start == datetime.datetime(2024, 1, 28, 10, 17, 59, 6000)
 
 def test_is_word_in_sentence():

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -282,3 +282,83 @@ def test_filter_and_tag_by_theme():
     df = filter_and_tag_by_theme(df1)
     debug_df(df)
     pd.testing.assert_frame_equal(df.reset_index(drop=True), expected_result.reset_index(drop=True))
+
+def test_complexe_filter_and_tag_by_theme():
+    df1 = pd.DataFrame([{
+        "start": 1704798000,
+        "plaintext": "cheese pizza habitabilité de la planète conditions de vie sur terre animal",
+        "channel_name": "m6",
+        "channel_radio": False,
+        "srt": [{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079004,
+            "text": "cheese"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079005,
+            "text": "pizza"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079006,
+            "text": "habitabilité"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079007,
+            "text": "de"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079008,
+            "text": "la"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079009,
+            "text": "planète"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079010,
+            "text": "conditions"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079011,
+            "text": "de"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079011,
+            "text": "vie"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079011,
+            "text": "sur"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079011,
+            "text": "terre"
+            },{
+            "duration_ms": 34,
+            "cts_in_ms": 1706437079012,
+            "text": "animal"
+            },
+        ],
+    }])
+
+    expected_result = pd.DataFrame([{
+        "start": 1704798000,
+        "plaintext": "cheese pizza habitabilité de la planète conditions de vie sur terre animal",
+        "channel_name": "m6",
+        "channel_radio": False,
+        "theme": [
+            "changement_climatique_constat",
+            "ressources_naturelles_concepts_generaux",
+        ],
+        "keywords_with_timestamp": [
+            {'habitabilité de la planète': 1706437079006},
+            {'conditions de vie sur terre': 1706437079010},
+            {'planète': 1706437079009},
+            {'terre': 1706437079011}
+        ]
+    }])
+
+    # List of words to filter on
+    df = filter_and_tag_by_theme(df1)
+    debug_df(df)
+    pd.testing.assert_frame_equal(df.reset_index(drop=True), expected_result.reset_index(drop=True))


### PR DESCRIPTION
## Ajout de 2 champs
Pour avoir plus de visibilité sur la données stockées (basé sur la présence ou non de mot clé), on rajoute ici 2 champs dans la base : 
* le mot clé 
* et son timecode
dans un seul champs `keywords_with_timestamp` 
* ajout du champs `number_of_keywords` pour compter directement à l'ecriture et faciliter le requetâge

Ce champs est fabriqué à partir du champs `srt` de l'API mediatree

## Detection des mots clés dans `srt` le champs json de mediatree
* pluriel et singulier (voiture et voitures) en utilisant seulement le mot clé singulier voiture
* prise en compte de l'espace lors de l'utilisation de quote (')

## Tâches
- [x] Sauvegarder PG du dictionnaire au format JSON
- [x] rendre la liste de mot clés permettant de détecter les thèmes uniques (risque de doublon)

## Avant
```
        "start": 1704798000,
        "plaintext":  "VACHE BOVIN Anthropocène",
        "channel_name": "m6",
        "channel_radio": False,
        "theme": [
            "changement_climatique_constat",
            "changement_climatique_causes_indirectes",
            "ressources_naturelles_concepts_generaux"
        ]
```

## Après
```
        "start": 1704798000,
        "plaintext":  "VACHE BOVIN Anthropocène",
        "channel_name": "m6",
        "channel_radio": False,
        "theme": [
            "changement_climatique_constat"
            "changement_climatique_causes_indirectes",
            "ressources_naturelles_concepts_generaux"
        ],
        "keywords_with_timestamp": [ {
              "keyword": 'vache': 
              "timestamp": TIMESTAMP
              "theme": "changement_climatique_causes_indirectes"
}]
      number_of_keywords: 1 
```