### PR TITLE
fix: use date gte lte instead of page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       POSTGRES_PORT: 5432
       PORT: 5050 # healthcheck
       HEALTHCHECK_SERVER: "0.0.0.0"
-      # START_DATE: 1705409797 # to test batch import 
+     # START_DATE: 1704576615 # to test batch import 
       MEDIATREE_USER : /run/secrets/username_api
       MEDIATREE_PASSWORD:  /run/secrets/pwd_api
       MEDIATREE_AUTH_URL: https://keywords.mediatree.fr/api/auth/token/

--- a/postgres/insert_data.py
+++ b/postgres/insert_data.py
@@ -40,7 +40,8 @@ def show_sitemaps_dataframe(df: pd.DataFrame):
             logging.warning("Could show sitemap before saving : \n %s \n %s" % (err, df.head(1).to_string()))
 
 def save_to_pg(df, table, conn):
-    logging.info(f"Saving to PG table '{table}'")
+    number_of_elements = len(df)
+    logging.info(f"Saving {number_of_elements} elements to PG table '{table}'")
     logging.debug("Saving %s" % (df.head(1).to_string()))
     try:
         logging.debug("Schema before saving\n%s", df.dtypes)

--- a/quotaclimat/data_processing/mediatree/keyword_processor.py
+++ b/quotaclimat/data_processing/mediatree/keyword_processor.py
@@ -1,4 +1,4 @@
-from flashtext import KeywordProcessor
+from flashtexpt import KeywordProcessor
 
 
 class KeywordModel:

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -43,20 +43,6 @@ def get_exact_days_from_week_day_name(
 
     return timestamps
 
-def date_to_epoch(date_string):
-    # Define the timezone
-    tz = pytz.timezone(timezone)
-
-    # Create a datetime object from the date string
-    date = datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S')
-
-    # Localize the datetime object to the specified timezone
-    date = tz.localize(date)
-
-    # Convert the datetime to epoch time in seconds
-    epoch_time = int(date.timestamp())
-    return epoch_time
-
 def get_epoch_from_datetime(date: datetime):
     return int(date.timestamp())
 
@@ -78,7 +64,24 @@ def get_start_end_date_env_variable_with_default():
 
     if start_date is not None:
         logging.info(f"Using START_DATE env var {start_date}")
-        return int(start_date)
+        return (int(start_date), get_yesterday())
     else:
         logging.info(f"Getting data from yesterday - you can use START_DATE env variable to provide another starting date")
-        return get_yesterday()
+        return (get_yesterday(), None)
+
+# to query the API every X hour
+def get_hour_frequency():
+    hour_frequency=12
+    return hour_frequency
+
+# Get range of 2 date by week from start to end
+def get_date_range(start_date_to_query, end_epoch):
+    if end_epoch is not None:
+        range = pd.date_range(pd.to_datetime(start_date_to_query, unit='s'), pd.to_datetime(end_epoch, unit='s'), freq=f"{get_hour_frequency()}h") # every X hour
+
+        logging.info(f"Date range: {range} \ {start_date_to_query} until {end_epoch}")
+        return range
+    else:
+        logging.info("Empty range using default from yesterday")
+        range = pd.date_range(start=get_datetime_yesterday(), periods=4, freq=f"{get_hour_frequency()}h")
+        return range

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -18,23 +18,21 @@ def test_get_yesterday():
 
 def test_get_date_range():
     range = get_date_range(1681214197, 1681646197)
-    expected = pd.DatetimeIndex(['2023-04-11 11:56:37', '2023-04-11 19:56:37',
-         '2023-04-12 03:56:37', '2023-04-12 11:56:37',
-         '2023-04-12 19:56:37', '2023-04-13 03:56:37',
-         '2023-04-13 11:56:37', '2023-04-13 19:56:37',
-         '2023-04-14 03:56:37', '2023-04-14 11:56:37',
-         '2023-04-14 19:56:37', '2023-04-15 03:56:37',
-         '2023-04-15 11:56:37', '2023-04-15 19:56:37',
-         '2023-04-16 03:56:37', '2023-04-16 11:56:37'],
-        dtype='datetime64[ns]', freq='8H')
+    expected = pd.DatetimeIndex(['2023-04-11 11:56:37', '2023-04-11 23:56:37',
+         '2023-04-12 11:56:37', '2023-04-12 23:56:37',
+         '2023-04-13 11:56:37', '2023-04-13 23:56:37',
+         '2023-04-14 11:56:37', '2023-04-14 23:56:37',
+         '2023-04-15 11:56:37', '2023-04-15 23:56:37',
+         '2023-04-16 11:56:37'],
+        dtype='datetime64[ns]', freq='12H')
     assert len(expected) == len(range) # ValueError: the 'dtype' parameter is not supported in the pandas implementation of any()
 
 def test_get_default_date_range():
     # test default
     range = get_date_range(get_yesterday(), None)
-    assert len(range) == 5
+    assert len(range) == 4
 
     # test with function
     (start_date_to_query, end_epoch) = get_start_end_date_env_variable_with_default()
     range = get_date_range(start_date_to_query, end_epoch)
-    assert len(range) == 5
+    assert len(range) == 4

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -2,19 +2,39 @@ import pytest
 import pandas as pd
 
 from utils import get_localhost
-from quotaclimat.data_processing.mediatree.utils import get_yesterday, date_to_epoch
+from quotaclimat.data_processing.mediatree.utils import get_yesterday, get_date_range, get_start_end_date_env_variable_with_default
 
 import logging
 from time import strftime,localtime
 
 localhost = get_localhost()
 
-def test_date_to_epoch():
-    epoch = date_to_epoch("2024-01-20 10:11:55")
-    assert epoch == 1705741915
-
 def test_get_yesterday():
     yesterday = get_yesterday()
     yesterday_string = strftime('%Y-%m-%d %H:%M:%S', localtime(yesterday))
     logging.info(f"yesterday_string {yesterday_string}")
     assert '00:00:00' in yesterday_string
+
+
+def test_get_date_range():
+    range = get_date_range(1681214197, 1681646197)
+    expected = pd.DatetimeIndex(['2023-04-11 11:56:37', '2023-04-11 19:56:37',
+         '2023-04-12 03:56:37', '2023-04-12 11:56:37',
+         '2023-04-12 19:56:37', '2023-04-13 03:56:37',
+         '2023-04-13 11:56:37', '2023-04-13 19:56:37',
+         '2023-04-14 03:56:37', '2023-04-14 11:56:37',
+         '2023-04-14 19:56:37', '2023-04-15 03:56:37',
+         '2023-04-15 11:56:37', '2023-04-15 19:56:37',
+         '2023-04-16 03:56:37', '2023-04-16 11:56:37'],
+        dtype='datetime64[ns]', freq='8H')
+    assert len(expected) == len(range) # ValueError: the 'dtype' parameter is not supported in the pandas implementation of any()
+
+def test_get_default_date_range():
+    # test default
+    range = get_date_range(get_yesterday(), None)
+    assert len(range) == 5
+
+    # test with function
+    (start_date_to_query, end_epoch) = get_start_end_date_env_variable_with_default()
+    range = get_date_range(start_date_to_query, end_epoch)
+    assert len(range) == 5


### PR DESCRIPTION
La pagination par "from" ne marche pas, cette PR propose d'utiliser les bons vieux 

- start_gte Start date greater or equal than (GTE), allowed format epoch and YYYY-MM-DDTHH:MM:SS
- start_lte : Start date greater or equal than (GTE), allowed format epoch and YYYY-MM-DDTHH:MM:SS

Avec une fréquence de une requete toutes les 12 heures

