### PR TITLE
CD: docker image set PROJECT_VERSION instead of always latest

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -35,11 +35,7 @@ jobs:
       run: |
         poetry install --only dev
         poetry version patch
-        git config user.name barometre-github-actions
-        git config user.email barometre-github-actions@github.com
-        git add pyproject.toml
-        git commit -m "[no ci]: bumping version"
-        git push origin main
+
         PROJECT_VERSION=$(poetry version --short)
         echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
     - name: Login to Scaleway Container Registry

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -24,10 +24,24 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: actions/checkout@v4
-    - name: Add version to environment vars
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: ${{ env.POETRY_VERSION }}
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+        installer-parallel: true
+    - name: Poetry install & bump version
       run: |
-          PROJECT_VERSION=$(poetry version --short)
-          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+        poetry install --only dev
+        poetry version patch
+        git config user.name barometre-github-actions
+        git config user.email barometre-github-actions@github.com
+        git add pyproject.toml
+        git commit -m "[no ci]: bumping version"
+        git push origin main
+        PROJECT_VERSION=$(poetry version --short)
+        echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
     - name: Login to Scaleway Container Registry
       uses: docker/login-action@v3
       with:
@@ -48,19 +62,3 @@ jobs:
       run: docker build -f Dockerfile_streamlit . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/streamlit
     - name: Push streamlit Image
       run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/streamlit
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        version: ${{ env.POETRY_VERSION }}
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-        installer-parallel: true
-    - name: Poetry install & bump version
-      run: |
-        poetry install --only dev
-        poetry version patch
-        git config user.name barometre-github-actions
-        git config user.email barometre-github-actions@github.com
-        git add pyproject.toml
-        git commit -m "[no ci]: bumping version"
-        git push origin main

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -37,11 +37,7 @@ jobs:
         poetry version patch
         PROJECT_VERSION=$(poetry version --short)
         echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-        git config user.name barometre-github-actions
-        git config user.email barometre-github-actions@github.com
-        git add pyproject.toml
-        git commit -m "[no ci]: bumping version ${{ env.PROJECT_VERSION }}"
-        git push origin main
+
     - name: Login to Scaleway Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -35,9 +35,13 @@ jobs:
       run: |
         poetry install --only dev
         poetry version patch
-
         PROJECT_VERSION=$(poetry version --short)
         echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+        git config user.name barometre-github-actions
+        git config user.email barometre-github-actions@github.com
+        git add pyproject.toml
+        git commit -m "[no ci]: bumping version ${{ env.PROJECT_VERSION }}"
+        git push origin main
     - name: Login to Scaleway Container Registry
       uses: docker/login-action@v3
       with:
@@ -51,7 +55,9 @@ jobs:
 
     - name: Build mediatree_import image
       run: docker build -f Dockerfile_api_import . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
-    - name: Push mediatree_import Image
+    - name: TAg mediatree_import latest image
+      run: docker tag ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }} ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:latest
+    - name: Push ingest_to_db Image
       run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
       
     - name: Build streamlit image

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -44,18 +44,19 @@ jobs:
         username: nologin
         password: ${{ secrets.SCALEWAY_API_KEY }}
         registry: ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}
-    - name: Build ingest_to_db image
-      run: docker build -f Dockerfile_ingest . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/ingest_to_db
-    - name: Push ingest_to_db Image
-      run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/ingest_to_db
 
     - name: Build mediatree_import image
       run: docker build -f Dockerfile_api_import . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
     - name: TAg mediatree_import latest image
       run: docker tag ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }} ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:latest
     - name: Push ingest_to_db Image
-      run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
-      
+      run: docker push --all-tags ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import
+
+    - name: Build ingest_to_db image
+      run: docker build -f Dockerfile_ingest . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/ingest_to_db
+    - name: Push ingest_to_db Image
+      run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/ingest_to_db
+
     - name: Build streamlit image
       run: docker build -f Dockerfile_streamlit . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/streamlit
     - name: Push streamlit Image

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -24,6 +24,10 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: actions/checkout@v4
+    - name: Add version to environment vars
+      run: |
+          PROJECT_VERSION=$(poetry version --short)
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
     - name: Login to Scaleway Container Registry
       uses: docker/login-action@v3
       with:
@@ -36,9 +40,9 @@ jobs:
       run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/ingest_to_db
 
     - name: Build mediatree_import image
-      run: docker build -f Dockerfile_api_import . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:test-pagination
+      run: docker build -f Dockerfile_api_import . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
     - name: Push mediatree_import Image
-      run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:test-pagination
+      run: docker push ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
       
     - name: Build streamlit image
       run: docker build -f Dockerfile_streamlit . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/streamlit

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -37,7 +37,11 @@ jobs:
         poetry version patch
         PROJECT_VERSION=$(poetry version --short)
         echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-
+        git config user.name barometre-github-actions
+        git config user.email barometre-github-actions@github.com
+        git add pyproject.toml
+        git commit -m "[no ci]: ${{ env.PROJECT_VERSION }} bumping version"
+        git push origin main
     - name: Login to Scaleway Container Registry
       uses: docker/login-action@v3
       with:
@@ -47,9 +51,9 @@ jobs:
 
     - name: Build mediatree_import image
       run: docker build -f Dockerfile_api_import . -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }}
-    - name: TAg mediatree_import latest image
+    - name: Tag mediatree_import latest image
       run: docker tag ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:${{ env.PROJECT_VERSION }} ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import:latest
-    - name: Push ingest_to_db Image
+    - name: Push mediatree_import Image
       run: docker push --all-tags ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/mediatree_import
 
     - name: Build ingest_to_db image


### PR DESCRIPTION
Scaleway can have cache problem on their docker registry, so i force the tag to the app version instead of latest

:warning: docker registry size