### PR TITLE
feat(update): use start_date instead of start_offset

### DIFF
--- a/.github/workflows/scaleway-down.yml
+++ b/.github/workflows/scaleway-down.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Use CLI
-      uses: jawher/action-scw@v2.24.0
+      uses: jawher/action-scw@v2.32.1
       env:
         SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
         SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
@@ -25,7 +25,7 @@ jobs:
 
 
     - name: 0 instances
-      uses: jawher/action-scw@v2.24.0
+      uses: jawher/action-scw@v2.32.1
       env:
         SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
         SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}

--- a/.github/workflows/scaleway-start-import-job-update.yml
+++ b/.github/workflows/scaleway-start-import-job-update.yml
@@ -2,44 +2,21 @@ name: Import job Scaleway
 
 on:
   workflow_dispatch: # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
-  
+
+
 jobs:
   start-job-image:
+    strategy:
+      matrix:
+        start_date: ["2023-04-01", "2023-05-01","2023-06-01","2023-07-01"]
     runs-on: ubuntu-latest
     steps:
-    - name: start import job to reapply logic to all elements offset 0
-      uses: jawher/action-scw@v2.27.0
+    - name: start import job to reapply logic to all elements start_date matrix
+      uses: jawher/action-scw@v2.32.1
       env:
         SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
         SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
         SCW_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
         SCW_ZONE: ${{ secrets.SCW_ZONE }}
       with:
-        args: jobs definition start ${{ secrets.SCALEWAY_JOB_IMPORT_ID }} environment-variables.UPDATE=true environment-variables.START_OFFSET=0
-    - name: start import job to reapply logic to all elements offset 300000
-      uses: jawher/action-scw@v2.27.0
-      env:
-        SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
-        SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-        SCW_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
-        SCW_ZONE: ${{ secrets.SCW_ZONE }}
-      with:
-        args: jobs definition start ${{ secrets.SCALEWAY_JOB_IMPORT_ID }} environment-variables.UPDATE=true environment-variables.START_OFFSET=300000
-    - name: start import job to reapply logic to all elements offset 600000
-      uses: jawher/action-scw@v2.27.0
-      env:
-        SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
-        SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-        SCW_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
-        SCW_ZONE: ${{ secrets.SCW_ZONE }}
-      with:
-        args: jobs definition start ${{ secrets.SCALEWAY_JOB_IMPORT_ID }} environment-variables.UPDATE=true environment-variables.START_OFFSET=600000
-    - name: start import job to reapply logic to all elements offset 900000
-      uses: jawher/action-scw@v2.27.0
-      env:
-        SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
-        SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-        SCW_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
-        SCW_ZONE: ${{ secrets.SCW_ZONE }}
-      with:
-        args: jobs definition start ${{ secrets.SCALEWAY_JOB_IMPORT_ID }} environment-variables.UPDATE=true environment-variables.START_OFFSET=900000
+        args: jobs definition start ${{ secrets.SCALEWAY_JOB_IMPORT_ID }} environment-variables.UPDATE=true environment-variables.START_DATE_UPDATE=${{ matrix.start_date }}

--- a/.github/workflows/scaleway-up.yml
+++ b/.github/workflows/scaleway-up.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Use CLI
-      uses: jawher/action-scw@v2.24.0
+      uses: jawher/action-scw@v2.32.1
       env:
         SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
         SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
@@ -24,7 +24,7 @@ jobs:
       run: echo "CONTAINER_ID=$(cat "${GITHUB_WORKSPACE}/scw.output" | jq -r '.[0].id')"  >> $GITHUB_ENV
 
     - name: start 1 instances
-      uses: jawher/action-scw@v2.24.0
+      uses: jawher/action-scw@v2.32.1
       env:
         SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
         SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}

--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ After having updated `UPDATE` env variable to true inside docker-compose.yml and
 We can adjust batch update with these env variables (as in the docker-compose.yml): 
 ```
 BATCH_SIZE: 50000 # number of records to update in one batch
-NUMBER_OF_BATCH: 4 # number of batch size to process
 ```
 
 ### Comparison between 15/20/30/40 window
@@ -308,13 +307,15 @@ The goal is to compare different durations to select one, it should be desactiva
 `UPDATE_PROGRAM_ONLY` to true will only update program metadata, otherwise, it will update program metadata and all theme/keywords calculations.
 
 ### Batch update from an offset
-With +1 millions rows, we can update from an offset to fix a custom logic by using `START_OFFSET` to batch update PG from a offset. 
+With +1 millions rows, we can update from an offset to fix a custom logic by using `START_DATE_UPDATE` (YYYY-MM-DD), the default will use the end of the month otherwise you can specify`END_DATE` (optional) (YYYY-MM-DD) to batch update PG from a date range.
 
 ~55 minutes to update 50K rows on a mVCPU 2240 - 4Gb RAM on Scaleway.
 
-Example inside the docker-compose.yml mediatree service -> START_OFFSET: 100
+Every month has ~80K rows.
 
-We can use [a Github actions to start multiple update operations with different offsets](https://github.com/dataforgoodfr/quotaclimat/blob/main/.github/workflows/scaleway-start-import-job-update.yml)
+Example inside the docker-compose.yml mediatree service -> START_DATE_UPDATE: 2024-04-01 - default END_DATE will be 2024-04-30
+ 
+We can use [a Github actions to start multiple update operations with different date, set it using the matrix](https://github.com/dataforgoodfr/quotaclimat/blob/main/.github/workflows/scaleway-start-import-job-update.yml)
 
 ## SQL Tables evolution
 Using [Alembic](https://alembic.sqlalchemy.org/en/latest/autogenerate.html) Auto Generating Migrations¶ we can add a new column inside `models.py` and it will automatically make the schema evolution :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     #entrypoint: ["python", "quotaclimat/data_processing/mediatree/api_import.py"]
     environment:
       ENV: docker # change me to prod for real cases
-      LOGLEVEL: WARNING # Change me to info (debug, info, warning, error) to have less log
+      LOGLEVEL: INFO # Change me to info (debug, info, warning, error) to have less log
       PYTHONPATH: /app
       POSTGRES_USER: user
       POSTGRES_DB: barometre
@@ -148,11 +148,11 @@ services:
       HEALTHCHECK_SERVER: "0.0.0.0"
       # SENTRY_DSN: prod_only
       # COMPARE_DURATION: "true"
-      # UPDATE: "true" # to batch update PG 
+      #UPDATE: "true" # to batch update PG 
       #UPDATE_PROGRAM_ONLY: "true" # to batch update PG but only channel with program
-      # START_OFFSET: 1 # to batch update PG from a offset
-      #BATCH_SIZE: 50000 # number of records to update in one batch
-      #NUMBER_OF_BATCH: 4 # number of batch size to process
+      #START_DATE_UPDATE: "2024-02-01" # to batch update PG from a date
+      #END_DATE: "2024-02-29" # optional - otherwise end of the month
+      BATCH_SIZE: 100 # number of records to update in one batch
       # START_DATE: 1717227223 # to test batch import 
       CHANNEL : france2 # to reimport only one channel
       MEDIATREE_USER : /run/secrets/username_api

--- a/postgres/insert_data.py
+++ b/postgres/insert_data.py
@@ -40,7 +40,6 @@ def show_sitemaps_dataframe(df: pd.DataFrame):
 def save_to_pg(df, table, conn):
     number_of_elements = len(df)
     logging.info(f"Saving {number_of_elements} elements to PG table '{table}'")
-    logging.debug("Saving %s" % (df.head(1).to_string()))
     try:
         logging.debug("Schema before saving\n%s", df.dtypes)
         df.to_sql(

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -49,19 +49,20 @@ def refresh_token(token, date):
 # reapply word detector logic to all saved keywords
 # use when word detection is changed
 async def update_pg_data(exit_event):
-    start_offset = int(os.environ.get("START_OFFSET", 0))
+    start_date = os.environ.get("START_DATE_UPDATE", "2023-04-01")
+    tmp_end_date = get_end_of_month(start_date)
+    end_date = os.environ.get("END_DATE", tmp_end_date)
     batch_size = int(os.environ.get("BATCH_SIZE", 50000))
-    number_of_batch = int(os.environ.get("NUMBER_OF_BATCH", 6))
     program_only = os.environ.get("UPDATE_PROGRAM_ONLY", "false") == "true"
     if(program_only):
         logging.warning("Update : Program only mode activated - UPDATE_PROGRAM_ONLY")
     else:
         logging.warning("Update : programs will not be updated for performance issue - use UPDATE_PROGRAM_ONLY to true for this")
 
-    logging.warning(f"Updating already saved data from Postgresql from offset {start_offset} - env variable START_OFFSET until {start_offset + number_of_batch * batch_size}")
+    logging.warning(f"Updating already saved data from Postgresql from date {start_date} - env variable START_DATE_UPDATE until {end_date} - you can use END_DATE to set it (optional)")
     try:
         session = get_db_session()
-        update_keywords(session, batch_size=batch_size, start_offset=start_offset, program_only=program_only, number_of_batch=number_of_batch)
+        update_keywords(session, batch_size=batch_size, start_date=start_date, program_only=program_only, end_date=end_date)
         exit_event.set()
     except Exception as err:
         logging.error("Could update_pg_data %s:(%s)" % (type(err).__name__, err))

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -5,6 +5,7 @@ import logging
 from zoneinfo import ZoneInfo
 import modin.pandas as pd
 import os 
+from pandas.tseries.offsets import MonthEnd
 
 timezone='Europe/Paris'
 
@@ -70,6 +71,11 @@ def get_yesterday():
     yesterday_timestamp = yesterday.timestamp()
 
     return int(yesterday_timestamp)
+
+def get_end_of_month(start_date: str) -> str:
+    date = pd.Timestamp(start_date) + MonthEnd(n=1)
+    date = pd.to_datetime(date, format='%Y%m%d')
+    return date.strftime('%Y-%m-%d')
 
 def get_start_end_date_env_variable_with_default():
     start_date = os.environ.get("START_DATE")

--- a/test/sitemap/test_main_import_api.py
+++ b/test/sitemap/test_main_import_api.py
@@ -30,7 +30,7 @@ def test_main_api_import():
         save_to_pg(df._to_pandas(), keywords_table, conn)
 
         session = get_db_session(conn)
-        saved_keywords = get_keywords_columns(session)
+        saved_keywords = get_keywords_columns(session, start_date="2024-02-01", end_date="2024-02-29")
         assert len(saved_keywords) == len(df)
 
 def test_first_row_api_import():

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -38,3 +38,8 @@ def test_is_it_tuesday():
 
     date = pd.Timestamp("2024-01-01 15:34:28")
     assert is_it_tuesday(date) == False
+
+def test_get_end_of_month():
+    assert get_end_of_month("2024-04-01") == "2024-04-30"
+    assert get_end_of_month("2024-02-01") == "2024-02-29"
+    assert get_end_of_month("2024-02-15") == "2024-02-29"

--- a/test/sitemap/test_update_pg_keywords.py
+++ b/test/sitemap/test_update_pg_keywords.py
@@ -191,7 +191,7 @@ def test_first_update_keywords():
     # check the value is well existing
     result_before_update = get_keyword(primary_key)
     session = get_db_session(conn)
-    update_keywords(session, batch_size=50)
+    update_keywords(session, batch_size=50, start_date="2024-01-01", end_date="2024-01-30")
     result_after_update = get_keyword(primary_key)
 
     new_theme, new_keywords_with_timestamp, new_value \


### PR DESCRIPTION
Plus pour les humains, on utilise maintenant la date de debut de MAJ plutôt que l'offset
---
With +1 millions rows, we can update from an offset to fix a custom logic by using `START_DATE_UPDATE` (YYYY-MM-DD), the default will use the end of the month otherwise you can specify`END_DATE` (optional) (YYYY-MM-DD) to batch update PG from a date range.

~55 minutes to update 50K rows on a mVCPU 2240 - 4Gb RAM on Scaleway.

Every month has ~80K rows.

Example inside the docker-compose.yml mediatree service -> START_DATE_UPDATE: 2024-04-01 - default END_DATE will be 2024-04-30
 
We can use [a Github actions to start multiple update operations with different date, set it using the matrix](https://github.com/dataforgoodfr/quotaclimat/blob/main/.github/workflows/scaleway-start-import-job-update.yml)