### PR TITLE
fix: use margin when updating program name

### DIFF
--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -152,12 +152,12 @@ def get_auth_token(password=password, user_name=USER):
 
 # see : https://keywords.mediatree.fr/docs/#api-Subtitle-SubtitleList
 def get_param_api(token, type_sub, start_epoch, channel, end_epoch):
-    epoch_5min_margin = 300
+
     return {
         "channel": channel,
         "token": token,
-        "start_gte": int(start_epoch) - epoch_5min_margin,
-        "start_lte": int(end_epoch) + epoch_5min_margin,
+        "start_gte": int(start_epoch) - EPOCH__5MIN_MARGIN,
+        "start_lte": int(end_epoch) + EPOCH__5MIN_MARGIN,
         "type": type_sub,
         "size": "1000" #  range 1-1000
     }
@@ -308,5 +308,4 @@ if __name__ == "__main__":
     getLogger()
     asyncio.run(main())
     sys.exit(0)
-
 

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -96,10 +96,10 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
                 logging.info(f"Updating program for keyword {keyword_id} - {channel_name} - converted tz : {start_tz}")
                 program_name, program_name_type = get_a_program_with_start_timestamp(df_programs, start_tz, channel_name)
                 update_keyword_row_program(session
-                ,keyword_id
-                ,channel_program=program_name
-                ,channel_program_type=program_name_type
-                ,channel_title=channel_title
+                    ,keyword_id
+                    ,channel_program=program_name
+                    ,channel_program_type=program_name_type
+                    ,channel_title=channel_title
                 )
         logging.info(f"bulk update done {i} out of {total_updates} - (max offset {total_updates})")
         session.commit()

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -8,6 +8,7 @@ import os
 from pandas.tseries.offsets import MonthEnd
 
 timezone='Europe/Paris'
+EPOCH__5MIN_MARGIN = 300
 
 def get_keyword_time_separation_ms(duration_seconds: int = 15):
     return duration_seconds * 1000

--- a/test/sitemap/test_program_metadata.py
+++ b/test/sitemap/test_program_metadata.py
@@ -195,7 +195,9 @@ def test_get_a_program_with_start_timestamp():
 def test_get_13h_program_with_start_timestamp():
     df_programs = get_programs()
     saturday_13h18 = 1717240693
-    program_name, program_type = get_a_program_with_start_timestamp(df_programs, pd.to_datetime(saturday_13h18, unit='s', utc=True).tz_convert('Europe/Paris'), channel_name)
+    program_name, program_type = get_a_program_with_start_timestamp(df_programs, \
+                                                                    pd.to_datetime(saturday_13h18, unit='s', utc=True).tz_convert('Europe/Paris'),\
+                                                                    channel_name)
     assert program_name == "13h15 le samedi"
     assert program_type == "Information - Journal"
 
@@ -205,6 +207,26 @@ def test_get_13h_monday_program_with_start_timestamp():
     program_name, program_type = get_a_program_with_start_timestamp(df_programs, pd.to_datetime(monday_13h18, unit='s', utc=True).tz_convert('Europe/Paris'), channel_name)
     assert program_name == "JT 13h"
     assert program_type == "Information - Journal"
+
+def test_get_13h_monday_rfi_program_with_start_timestamp():
+    df_programs = get_programs()
+    monday_13h05 = 1726398337
+    program_name, program_type = get_a_program_with_start_timestamp(df_programs,\
+                                                                    pd.to_datetime(monday_13h05, unit='s', utc=True).tz_convert('Europe/Paris'),\
+                                                                    "rfi")
+    assert program_name == "Journal - 13h"
+    assert program_type == "Information - Journal"
+
+
+def test_get_13h_monday_rfi_with_margin_program_with_start_timestamp():
+    df_programs = get_programs()
+    monday_13h12 = 1726398730
+    program_name, program_type = get_a_program_with_start_timestamp(df_programs,\
+                                                                    pd.to_datetime(monday_13h12, unit='s', utc=True).tz_convert('Europe/Paris'),\
+                                                                    "rfi")
+    assert program_name == "Journal - 13h"
+    assert program_type == "Information - Journal"
+
 
 def test_compare_weekday_string():
     assert compare_weekday('*', 0) == True


### PR DESCRIPTION
Lors de l'import des données de l'API mediatree, nous prenons +5 minutes avant et après le programme pour être généreux sur les imports

Les MAJ (avec `UPDATE=true`) ne prennaient pas en compte cette marge, et les programmes avec les marges se retrouvaient avec leur champs programmes vides.

Cette PR fix cela