### PR TITLE
refacto: api-to-s3 :default time from 1 to 7

### DIFF
--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -51,7 +51,7 @@ BUCKET_NAME = os.environ.get("BUCKET_NAME")
 REGION = 'fr-par'
 
 ENDPOINT_URL = f'https://s3.{REGION}.scw.cloud'
-
+number_of_previous_days = 7 # to replay data if a job has failed
 s3_client = boto3.client(
     service_name='s3',
     region_name=REGION,
@@ -138,8 +138,7 @@ async def get_and_save_api_data(exit_event):
 
             token=get_auth_token(password=password, user_name=USER)
             type_sub = 's2t'
-
-            (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default()
+            (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(number_of_previous_days)
             df_programs = get_programs()
             channels = get_channels()
             

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -64,9 +64,9 @@ def get_min_hour(date: datetime):
 def get_max_hour(date: datetime):
     return datetime.combine(date, time.max)
 
-def get_datetime_yesterday():
+def get_datetime_yesterday(days=1):
     midnight_today = get_min_hour(get_now())
-    return midnight_today - timedelta(days=1)
+    return midnight_today - timedelta(days=days)
 
 def get_yesterday():
     yesterday = get_datetime_yesterday()
@@ -79,12 +79,12 @@ def get_end_of_month(start_date: str) -> str:
     date = pd.to_datetime(date, format='%Y%m%d')
     return date.strftime('%Y-%m-%d')
 
-def get_start_end_date_env_variable_with_default():
+def get_start_end_date_env_variable_with_default(days=1):
     start_date = os.environ.get("START_DATE")
 
     if start_date is not None:
         logging.info(f"Using START_DATE env var {start_date}")
-        return (int(start_date), get_yesterday())
+        return (int(start_date), get_yesterday(days))
     else:
         logging.info(f"Getting data from yesterday - you can use START_DATE env variable to provide another starting date")
         return (get_yesterday(), None)


### PR DESCRIPTION
to have a safety nets, check the previous 7 days if there is missing data and reimport if missing