### PR TITLE
fix: date import - cron monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ docker compose up mediatree
 
 ### Configuration - Batch import
 ### Based on time
-If our media perimeter evolves, we have to reimport it all using env variable `START_DATE` like in docker compose (epoch second format : 1705409797).
+If our media perimeter evolves, we have to reimport it all using env variable `START_DATE` like in docker compose (epoch second format : 1705409797). By default, it will import 30 days, you can modify it with `NUMBER_OF_PREVIOUS_DAYS` (integer).
 
 Otherwise, default is yesterday midnight date (default cron job)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,8 @@ services:
       #START_DATE_UPDATE: "2024-02-01" # to batch update PG from a date
       #END_DATE: "2024-02-29" # optional - otherwise end of the month
       BATCH_SIZE: 100 # number of records to update in one batch
-     # START_DATE: 1727610071 # to test batch import 
+      #START_DATE: 1727610071 # to test batch import 
+      # NUMBER_OF_PREVIOUS_DAYS: 30 # to query mediatree api only - not used for update
       CHANNEL : fr3-idf # to reimport only one channel
       MEDIATREE_USER : /run/secrets/username_api
       MEDIATREE_PASSWORD:  /run/secrets/pwd_api

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -94,8 +94,9 @@ async def get_and_save_api_data(exit_event):
             conn = connect_to_db()
             token=get_auth_token(password=password, user_name=USER)
             type_sub = 's2t'
-
-            (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default()
+            start_date = int(os.environ.get("START_DATE"))
+            number_of_previous_days = int(os.environ.get("NUMBER_OF_PREVIOUS_DAYS", 30))
+            (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days)
             df_programs = get_programs()
             channels = get_channels()
             
@@ -106,6 +107,7 @@ async def get_and_save_api_data(exit_event):
                 
                 for channel in channels:
                     try:
+                        logging.info("Querying day %s for channel %s" % (day, channel))
                         programs_for_this_day = get_programs_for_this_day(day.tz_localize("Europe/Paris"), channel, df_programs)
 
                         for program in programs_for_this_day.itertuples(index=False):

--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -51,7 +51,7 @@ BUCKET_NAME = os.environ.get("BUCKET_NAME")
 REGION = 'fr-par'
 
 ENDPOINT_URL = f'https://s3.{REGION}.scw.cloud'
-number_of_previous_days = 7 # to replay data if a job has failed
+
 s3_client = boto3.client(
     service_name='s3',
     region_name=REGION,
@@ -139,6 +139,7 @@ async def get_and_save_api_data(exit_event):
             token=get_auth_token(password=password, user_name=USER)
             type_sub = 's2t'
             start_date = int(os.environ.get("START_DATE"))
+            number_of_previous_days = int(os.environ.get("NUMBER_OF_PREVIOUS_DAYS", 7))
             (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days)
             df_programs = get_programs()
             channels = get_channels()

--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -138,7 +138,8 @@ async def get_and_save_api_data(exit_event):
 
             token=get_auth_token(password=password, user_name=USER)
             type_sub = 's2t'
-            (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(number_of_previous_days)
+            start_date = int(os.environ.get("START_DATE"))
+            (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days)
             df_programs = get_programs()
             channels = get_channels()
             
@@ -183,7 +184,7 @@ async def get_and_save_api_data(exit_event):
             sys.exit(1)
 
 async def main():
-    with monitor(monitor_slug='mediatree'): #https://docs.sentry.io/platforms/python/crons/
+    with monitor(monitor_slug='api-to-s3'): #https://docs.sentry.io/platforms/python/crons/
         try:
             logging.info("Start api to S3")
             

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -68,8 +68,8 @@ def get_datetime_yesterday(days=1):
     midnight_today = get_min_hour(get_now())
     return midnight_today - timedelta(days=days)
 
-def get_yesterday():
-    yesterday = get_datetime_yesterday()
+def get_yesterday(days=1):
+    yesterday = get_datetime_yesterday(days=1)
     yesterday_timestamp = yesterday.timestamp()
 
     return int(yesterday_timestamp)
@@ -79,12 +79,11 @@ def get_end_of_month(start_date: str) -> str:
     date = pd.to_datetime(date, format='%Y%m%d')
     return date.strftime('%Y-%m-%d')
 
-def get_start_end_date_env_variable_with_default(days=1):
-    start_date = os.environ.get("START_DATE")
-
+def get_start_end_date_env_variable_with_default(start_date:int, minus_days:int=1):
     if start_date is not None:
-        logging.info(f"Using START_DATE env var {start_date}")
-        return (int(start_date), get_yesterday(days))
+        start_date_minus_days = int(int(start_date) - (minus_days * 24 * 60 * 60))
+        logging.info(f"Using START_DATE env var {start_date} - to get {minus_days} day(s) before (env var NUMBER_OF_PREVIOUS_DAYS) : {start_date_minus_days}")
+        return (int(start_date), start_date_minus_days)
     else:
         logging.info(f"Getting data from yesterday - you can use START_DATE env variable to provide another starting date")
         return (get_yesterday(), None)
@@ -92,9 +91,10 @@ def get_start_end_date_env_variable_with_default(days=1):
 # Get range of 2 date by week from start to end
 def get_date_range(start_date_to_query, end_epoch):
     if end_epoch is not None:
-        range = pd.date_range(pd.to_datetime(start_date_to_query, unit='s').normalize(),
-                              pd.to_datetime(end_epoch, unit='s').normalize()
-                            , freq="D")
+        logging.info(f"Getting date range from {pd.to_datetime(start_date_to_query, unit='s').normalize()} - {pd.to_datetime(end_epoch, unit='s').normalize()}")
+        range = pd.date_range( pd.to_datetime(end_epoch, unit='s').normalize(),
+                              pd.to_datetime(start_date_to_query, unit='s').normalize(),
+                              freq="D")
 
         logging.info(f"Date range: {range} \n {start_date_to_query} until {end_epoch}")
         return range

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -15,23 +15,6 @@ def test_get_yesterday():
     logging.info(f"yesterday_string {yesterday_string}")
     assert '00:00:00' in yesterday_string
 
-
-def test_get_date_range():
-    range = get_date_range(1681214197, 1681646197) # 11 to 16 april --> 6 days
-
-    assert 6  == len(range) # ValueError: the 'dtype' parameter is not supported in the pandas implementation of any()
-
-def test_get_default_date_range():
-    # test default
-    range = get_date_range(get_yesterday(), None)
-    assert len(range) == 1
-
-    # test with function
-    (start_date_to_query, end_epoch) = get_start_end_date_env_variable_with_default()
-    range = get_date_range(start_date_to_query, end_epoch)
-    assert len(range) == 1
-
-
 def test_is_it_tuesday():
     date = pd.Timestamp("2024-02-13 15:34:28")
     assert is_it_tuesday(date) == True

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -43,3 +43,29 @@ def test_get_end_of_month():
     assert get_end_of_month("2024-04-01") == "2024-04-30"
     assert get_end_of_month("2024-02-01") == "2024-02-29"
     assert get_end_of_month("2024-02-15") == "2024-02-29"
+
+
+
+def test_get_start_end_date_env_variable_with_default():
+    start_date = None
+    
+    assert get_start_end_date_env_variable_with_default(start_date, minus_days=1) == (get_yesterday(), None)
+
+def test_get_start_end_date_env_variable_with_start_date_value():
+    start_date = 1734508085
+    number_of_previous_days = 7
+    start_date_minus_days = start_date - (number_of_previous_days * 24 * 60 * 60)
+
+    assert get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days) == (int(start_date), start_date_minus_days)
+
+def test_get_start_end_date_with_get_date_range():
+    start_date = 1734508085
+    number_of_previous_days = 7
+    (start,end) = get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days)
+
+    expected = pd.DatetimeIndex(['2024-12-11', '2024-12-12', '2024-12-13', '2024-12-14', '2024-12-15', '2024-12-16', '2024-12-17', '2024-12-18'],
+                        dtype='datetime64[ns]', freq='D')
+    
+    output = get_date_range(start,end)
+    assert len(output) == number_of_previous_days + 1
+    pd.testing.assert_index_equal(output, expected)


### PR DESCRIPTION
# Fixes : 
* Sentry cron monitor for api-to-s3
* Date management 
1. feat : mediatree import : can specify how many days we want to query thanks to `NUMBER_OF_PREVIOUS_DAYS` : int default with 30
2. fix : api-to-s3 - security nets with `NUMBER_OF_PREVIOUS_DAYS` : int default with 7