### PR TITLE
fix: default to 0 when missing value for start date

### DIFF
--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -94,7 +94,7 @@ async def get_and_save_api_data(exit_event):
             conn = connect_to_db()
             token=get_auth_token(password=password, user_name=USER)
             type_sub = 's2t'
-            start_date = int(os.environ.get("START_DATE"))
+            start_date = int(os.environ.get("START_DATE", 0))
             number_of_previous_days = int(os.environ.get("NUMBER_OF_PREVIOUS_DAYS", 30))
             (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days)
             df_programs = get_programs()

--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -138,7 +138,7 @@ async def get_and_save_api_data(exit_event):
 
             token=get_auth_token(password=password, user_name=USER)
             type_sub = 's2t'
-            start_date = int(os.environ.get("START_DATE"))
+            start_date = int(os.environ.get("START_DATE", 0))
             number_of_previous_days = int(os.environ.get("NUMBER_OF_PREVIOUS_DAYS", 7))
             (start_date_to_query, end_date) = get_start_end_date_env_variable_with_default(start_date, minus_days=number_of_previous_days)
             df_programs = get_programs()

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -80,7 +80,7 @@ def get_end_of_month(start_date: str) -> str:
     return date.strftime('%Y-%m-%d')
 
 def get_start_end_date_env_variable_with_default(start_date:int, minus_days:int=1):
-    if start_date is not None:
+    if start_date != 0:
         start_date_minus_days = int(int(start_date) - (minus_days * 24 * 60 * 60))
         logging.info(f"Using START_DATE env var {start_date} - to get {minus_days} day(s) before (env var NUMBER_OF_PREVIOUS_DAYS) : {start_date_minus_days}")
         return (int(start_date), start_date_minus_days)

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -30,7 +30,7 @@ def test_get_end_of_month():
 
 
 def test_get_start_end_date_env_variable_with_default():
-    start_date = None
+    start_date = 0
     
     assert get_start_end_date_env_variable_with_default(start_date, minus_days=1) == (get_yesterday(), None)
 


### PR DESCRIPTION
fix `int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` 