### PR TITLE
feat: update with start date default to today minus X days

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,15 +322,21 @@ Use env variable `CHANNEL` like in docker compose (string: tf1) with `UPDATE` to
 `UPDATE_PROGRAM_CHANNEL_EMPTY_ONLY` to true will only update program metadata with empty value : "".
 
 ### Batch update from a date
-With +1 millions rows, we can update from an offset to fix a custom logic by using `START_DATE_UPDATE` (YYYY-MM-DD - default first day of the current month), the default will use the end of the month otherwise you can specify`END_DATE` (optional) (YYYY-MM-DD) to batch update PG from a date range.
+With +1 millions rows, we can update from an offset to fix a custom logic by using `START_DATE_UPDATE` (YYYY-MM-DD - default first day of the current month), the default will use the end of the month otherwise you can specify `END_DATE` (optional) (YYYY-MM-DD) to batch update PG from a date range.
 
-~55 minutes to update 50K rows on a mVCPU 2240 - 4Gb RAM on Scaleway.
-
-Every month has ~80K rows.
+Env variables list : 
+* START_DATE_UPDATE : string (YYYY-MM-DD ) - default to today - minus NUMBER_OF_DAYS (date is included in the query)
+* END_DATE : string (YYYY-MM-DD ) - default to end of the month (date is included in the query)
+* NUMBER_OF_DAYS : integer default to 7 days - number of days to update from (START_DATE_UPDATE - NUMBER_OF_DAYS) until START_DATE_UPDATE if START_DATE_UPDATE is empty
 
 Example inside the docker-compose.yml mediatree service -> START_DATE_UPDATE: 2024-04-01 - default END_DATE will be 2024-04-30
  
 We can use [a Github actions to start multiple update operations with different date, set it using the matrix](https://github.com/dataforgoodfr/quotaclimat/blob/main/.github/workflows/scaleway-start-import-job-update.yml)
+
+
+#### Production executions
+~55 minutes to update 50K rows on a mVCPU 2240 - 4Gb RAM on Scaleway.
+Every month has ~80K rows.
 
 ## SQL Tables evolution
 Using [Alembic](https://alembic.sqlalchemy.org/en/latest/autogenerate.html) Auto Generating Migrations¶ we can add a new column inside `models.py` and it will automatically make the schema evolution :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,9 +190,10 @@ services:
       HEALTHCHECK_SERVER: "0.0.0.0"
       # SENTRY_DSN: prod_only
       # COMPARE_DURATION: "true"
-      # UPDATE: "true" # to batch update PG 
+      UPDATE: "true" # to batch update PG 
       #UPDATE_PROGRAM_ONLY: "true" # to batch update PG but only channel with program
-      #START_DATE_UPDATE: "2024-02-01" # to batch update PG from a date
+      START_DATE_UPDATE: "2024-02-01" # to batch update PG from a date
+      # NUMBER_OF_DAYS: 7
       #END_DATE: "2024-02-29" # optional - otherwise end of the month
       BATCH_SIZE: 100 # number of records to update in one batch
       #START_DATE: 1727610071 # to test batch import 

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -93,6 +93,10 @@ def get_first_of_month(start_date: datetime) -> str:
     # Format as DD-MM-YYYY
     return first_day.strftime("%Y-%m-%d")
 
+def get_date_now_minus_days(start: datetime, minus_days: int):
+    new_date = start - timedelta(days=minus_days)
+    return new_date.strftime("%Y-%m-%d")
+
 def get_start_end_date_env_variable_with_default(start_date:int, minus_days:int=1):
     if start_date != 0:
         start_date_minus_days = int(int(start_date) - (minus_days * 24 * 60 * 60))

--- a/test/sitemap/test_mediatree_utils.py
+++ b/test/sitemap/test_mediatree_utils.py
@@ -37,6 +37,12 @@ def test_get_first_of_month():
     date = datetime(2024, 12, 12, 0, 0, 0)
     assert get_first_of_month(date) == "2024-12-01"
 
+def test_get_date_now_minus_days():
+    date = datetime(2024, 12, 12, 0, 0, 0)
+    assert get_date_now_minus_days(start=date, minus_days=6) == "2024-12-06"
+    assert get_date_now_minus_days(start=date, minus_days=13) == "2024-11-29"
+
+
 def test_get_start_end_date_env_variable_with_default():
     start_date = 0
     


### PR DESCRIPTION
Env variables list : 
* START_DATE_UPDATE : string (YYYY-MM-DD ) - default to today - minus NUMBER_OF_DAYS (date is included in the query)
* END_DATE : string (YYYY-MM-DD ) - default to end of the month (date is included in the query)
* NUMBER_OF_DAYS : integer default to 7 days - number of days to update from (START_DATE_UPDATE - NUMBER_OF_DAYS) until START_DATE_UPDATE if START_DATE_UPDATE is empty
