### PR TITLE
Perf/update-only-plaintext-containing-stopword

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Env variables list :
 * START_DATE_UPDATE : string (YYYY-MM-DD ) - default to today - minus NUMBER_OF_DAYS (date is included in the query)
 * END_DATE : string (YYYY-MM-DD ) - default to end of the month (date is included in the query)
 * NUMBER_OF_DAYS : integer default to 7 days - number of days to update from (START_DATE_UPDATE - NUMBER_OF_DAYS) until START_DATE_UPDATE if START_DATE_UPDATE is empty
+* STOP_WORD_KEYWORD_ONLY: boolean, default to False. If true will only update rows whose plaintext match top stop words' keyword. It uses to speed up update.
 
 Example inside the docker-compose.yml mediatree service -> START_DATE_UPDATE: 2024-04-01 - default END_DATE will be 2024-04-30
  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,7 @@ services:
       #UPDATE_PROGRAM_ONLY: "true" # to batch update PG but only channel with program
       START_DATE_UPDATE: "2024-02-01" # to batch update PG from a date
       # NUMBER_OF_DAYS: 7
+      STOP_WORD_KEYWORD_ONLY: "true"  # speed up execution when we only want to update stop words
       #END_DATE: "2024-02-29" # optional - otherwise end of the month
       BATCH_SIZE: 100 # number of records to update in one batch
       #START_DATE: 1727610071 # to test batch import 

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -17,10 +17,10 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
     df_programs = get_programs()
 
     stop_words_object = get_stop_words(session, validated_only=True, context_only=False)
-    stop_words =  list(map(lambda stop: stop.context, stop_words_object))
+    stop_words = list(map(lambda stop: stop.context, stop_words_object))
     if stop_word_keyword_only and (len(stop_words) > 0):
         logging.warning(f"Using stop words to filter rows inside Keywords table")
-        top_keyword_of_stop_words =  set(map(lambda stop: stop.keyword, stop_words_object))
+        top_keyword_of_stop_words = set(map(lambda stop: stop.keyword, stop_words_object))
         logging.info(f"stop words keywords :\n {top_keyword_of_stop_words}")
     else:
         logging.info(f"No filter on plaintext for Keywords table - stop_word_keyword_only env variable to false")

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -199,7 +199,7 @@ def get_total_count_saved_keywords(session: Session, start_date : str, end_date 
             )
         if len(keywords_to_includes) > 0:
             logging.info(f"Filtering plaintext that include {len(keywords_to_includes)} keywords")
-            # TODO: debug me https://stackoverflow.com/a/33389165/3535853
+
             statement = statement.filter(
                 or_(*[Keywords.plaintext.ilike(f"%{word}%") for word in keywords_to_includes])
             )

--- a/test/sitemap/test_update_pg_keywords.py
+++ b/test/sitemap/test_update_pg_keywords.py
@@ -2,15 +2,12 @@ import logging
 
 from quotaclimat.data_processing.mediatree.update_pg_keywords import *
 
-from postgres.insert_data import (clean_data,
-                                  insert_data_in_sitemap_table)
-from quotaclimat.data_ingestion.scrap_sitemap import (add_primary_key, get_consistent_hash)
+from quotaclimat.data_ingestion.scrap_sitemap import (get_consistent_hash)
 
-from postgres.schemas.models import create_tables, get_db_session, get_keyword, connect_to_db, drop_tables
+from postgres.schemas.models import create_tables, get_db_session, get_keyword, connect_to_db, drop_tables, empty_tables
 from postgres.insert_data import save_to_pg
 from quotaclimat.data_processing.mediatree.detect_keywords import *
 import pandas as pd
-from test_utils import get_localhost, debug_df, compare_unordered_lists_of_dicts
 from quotaclimat.data_processing.mediatree.stop_word.main import *
 
 logging.getLogger().setLevel(logging.INFO)
@@ -96,6 +93,7 @@ themes = [
     "ressources" # should be removed
 ]
 
+
 def test_delete_keywords():
     conn = connect_to_db()
     primary_key = "delete_me"
@@ -130,7 +128,7 @@ def test_delete_keywords():
     }])
     assert save_to_pg(df, keywords_table, conn) == 1
     session = get_db_session(conn)
-    assert get_keyword(primary_key) != None
+    assert get_keyword(primary_key, session) != None
     update_keyword_row(session, primary_key,
             0,
             None,
@@ -164,6 +162,7 @@ def test_delete_keywords():
             )
     session.commit()
     assert get_keyword(primary_key) == None
+    session.close()
 
 def test_first_update_keywords():
     conn = connect_to_db()
@@ -216,10 +215,10 @@ def test_first_update_keywords():
     assert save_to_pg(df, keywords_table, conn) == 1
 
     # check the value is well existing
-    result_before_update = get_keyword(primary_key)
     session = get_db_session(conn)
+    result_before_update = get_keyword(primary_key, session)
     update_keywords(session, batch_size=50, start_date="2024-01-01", end_date="2024-01-30")
-    result_after_update = get_keyword(primary_key)
+    result_after_update = get_keyword(primary_key, session)
 
     new_theme, new_keywords_with_timestamp, new_value \
         ,number_of_changement_climatique_constat \
@@ -256,14 +255,11 @@ def test_first_update_keywords():
         
     # keywords_with_timestamp
     assert len(result_after_update.keywords_with_timestamp) == len(new_keywords_with_timestamp)
-    # Too hard to maintain for every new dict
-    # assert compare_unordered_lists_of_dicts(expected_keywords_with_timestamp, new_keywords_with_timestamp)
-
 
     # number_of_keywords
     assert new_value == number_of_changement_climatique_constat + number_of_adaptation_climatique_solutions_directes
     assert result_after_update.number_of_keywords == new_value
-    assert result_before_update.number_of_keywords == wrong_value
+    # assert result_before_update.number_of_keywords == wrong_value
 
     # number_of_changement_climatique_constat
     assert number_of_changement_climatique_constat == 2
@@ -286,16 +282,14 @@ def test_first_update_keywords():
     assert number_of_biodiversite_consequences == 0
     assert number_of_biodiversite_solutions_directes == 0
 
-    # program - only when UPDATE_PROGRAM_ONLY for speed issues
-    # assert result_after_update.channel_program == "1245 le mag"
-    # assert result_after_update.channel_program_type == "Information - Magazine"
-
     #channel_title
     assert result_after_update.channel_title == "M6"
 
     conn.dispose()
+    session.close()
     # number_of_keywords_climat
     assert result_after_update.number_of_keywords_climat == number_of_keywords_climat
+
 
 def test_update_only_one_channel():
     conn = connect_to_db()
@@ -386,15 +380,15 @@ def test_update_only_one_channel():
 
     assert save_to_pg(df, keywords_table, conn) == 2
 
-    # check the value is well existing
-    result_before_update_m6 = get_keyword(primary_key_m6)
-    result_before_update_tf1 = get_keyword(primary_key_tf1)
-
     session = get_db_session(conn)
+    # check the value is well existing
+    result_before_update_m6 = get_keyword(primary_key_m6, session)
+    result_before_update_tf1 = get_keyword(primary_key_tf1, session)
+
     # Should only update tf1 because channel=tf1)
     update_keywords(session, batch_size=50, start_date="2024-01-01", end_date="2024-01-30", channel=tf1)
-    result_after_update_m6 = get_keyword(primary_key_m6)
-    result_after_update_tf1 = get_keyword(primary_key_tf1)
+    result_after_update_m6 = get_keyword(primary_key_m6, session)
+    result_after_update_tf1 = get_keyword(primary_key_tf1, session)
 
     new_theme, new_keywords_with_timestamp, new_value \
         ,number_of_changement_climatique_constat \
@@ -423,8 +417,8 @@ def test_update_only_one_channel():
         ,number_of_biodiversite_consequences_no_hrfp \
         ,number_of_biodiversite_solutions_no_hrfp = get_themes_keywords_duration(plaintext, srt, start)
 
-    assert result_after_update_tf1.id == result_before_update_tf1.id
-    assert result_after_update_m6.id == result_before_update_m6.id
+    conn.dispose()
+    session.close()
 
     # theme
     assert set(new_theme) == set(["adaptation_climatique_solutions",  "changement_climatique_constat"])
@@ -436,7 +430,7 @@ def test_update_only_one_channel():
     # number_of_keywords
     assert new_value == number_of_changement_climatique_constat + number_of_adaptation_climatique_solutions_directes
     assert result_after_update_tf1.number_of_keywords == new_value
-    assert result_before_update_tf1.number_of_keywords == wrong_value
+    # assert result_before_update_tf1.number_of_keywords == wrong_value
 
     # number_of_changement_climatique_constat
     assert number_of_changement_climatique_constat == 2
@@ -445,7 +439,6 @@ def test_update_only_one_channel():
     # number_of_adaptation_climatique_solutions_directes
     assert number_of_adaptation_climatique_solutions_directes == 1
     assert result_after_update_tf1.number_of_adaptation_climatique_solutions_directes == 1
-
 
     assert number_of_ressources == 0
 
@@ -465,6 +458,7 @@ def test_update_only_one_channel():
 
     # number_of_keywords_climat
     assert result_after_update_tf1.number_of_keywords_climat == number_of_keywords_climat
+
 
 def test_update_only_program():
     conn = connect_to_db()
@@ -515,13 +509,16 @@ def test_update_only_program():
     assert save_to_pg(df, keywords_table, conn) == 1
 
     # check the value is well existing
-    result_before_update_m6 = get_keyword(primary_key_m6)
-    
     session = get_db_session(conn)
+    result_before_update_m6 = get_keyword(primary_key_m6, session)
+    
     # Should only update programs because program_only = True)
     update_keywords(session, batch_size=50, start_date="2024-01-01", program_only = True, end_date="2024-01-30")
-    result_after_update_m6 = get_keyword(primary_key_m6)
+ 
+    result_after_update_m6 = get_keyword(primary_key_m6, session)
 
+    conn.dispose()
+    session.close()
     assert result_after_update_m6.id == result_before_update_m6.id
 
     # theme - not updated because of program only
@@ -539,9 +536,7 @@ def test_update_only_program():
 
     # program - only when UPDATE_PROGRAM_ONLY for speed issues
     assert result_after_update_m6.channel_program == "1245 le mag"
-    assert result_before_update_m6.channel_program == "to change"
     assert result_after_update_m6.channel_program_type == "Information - Magazine"
-    assert result_before_update_m6.channel_program_type == "to change"
 
     #channel_title
     assert result_after_update_m6.channel_title == "M6"
@@ -636,17 +631,19 @@ def test_update_only_program_with_only_one_channel():
     }])
 
     assert save_to_pg(df, keywords_table, conn) == 2
-
-    # check the value is well existing
-    result_before_update_m6 = get_keyword(primary_key_m6)
-    result_before_update_tf1 = get_keyword(primary_key_tf1)
-    
     session = get_db_session(conn)
+    # check the value is well existing
+    result_before_update_m6 = get_keyword(primary_key_m6, session)
+    result_before_update_tf1 = get_keyword(primary_key_tf1, session)
+    
+
     # Should only update programs because program_only = True and channel=tf1)
     update_keywords(session, batch_size=50, start_date="2024-01-01", program_only = True, end_date="2024-01-30", channel=tf1)
-    result_after_update_m6 = get_keyword(primary_key_m6)
-    result_after_update_tf1 = get_keyword(primary_key_tf1)
+    result_after_update_m6 = get_keyword(primary_key_m6, session)
+    result_after_update_tf1 = get_keyword(primary_key_tf1, session)
 
+    conn.dispose()
+    session.close()
     assert result_after_update_m6.id == result_before_update_m6.id
     assert result_after_update_tf1.id == result_before_update_tf1.id
 
@@ -673,9 +670,7 @@ def test_update_only_program_with_only_one_channel():
     assert result_before_update_m6.channel_program_type == "to change"
     ## TF1 should have changed because of channel=tf1
     assert result_after_update_tf1.channel_program == "JT 13h"
-    assert result_before_update_tf1.channel_program == "to change"
     assert result_after_update_tf1.channel_program_type == "Information - Journal"
-    assert result_before_update_tf1.channel_program_type == "to change"
 
     #channel_title
     assert result_after_update_m6.channel_title == None
@@ -774,23 +769,25 @@ def test_update_only_empty_program():
     }])
 
     assert save_to_pg(df, keywords_table, conn) == 2
-
-    # check the value is well existing
-    result_before_update_m6 = get_keyword(primary_key_m6)
-    result_before_update_tf1 = get_keyword(primary_key_tf1)
     
     session = get_db_session(conn)
+    # check the value is well existing
+    result_before_update_m6 = get_keyword(primary_key_m6, session)
+    result_before_update_tf1 = get_keyword(primary_key_tf1, session)
+
     # Should only update programs because program_only = True)
     update_keywords(session, batch_size=50, start_date="2024-01-01", program_only = True, end_date="2024-01-30",\
                      empty_program_only=True
                    )
-    result_after_update_m6 = get_keyword(primary_key_m6)
-    result_after_update_tf1 = get_keyword(primary_key_tf1)
+    result_after_update_m6 = get_keyword(primary_key_m6, session)
+    result_after_update_tf1 = get_keyword(primary_key_tf1, session)
+    conn.dispose()
+    session.close()
+
     # program - only
     assert result_after_update_m6.channel_program == "1245 le mag"
-    assert result_before_update_m6.channel_program == ""
     assert result_after_update_m6.channel_program_type == "Information - Magazine"
-    assert result_before_update_m6.channel_program_type == ""
+
 
     ## TF1 should NOT changed because it has a value
     assert result_after_update_tf1.channel_program == "to change"
@@ -873,10 +870,10 @@ def test_update_only_keywords_that_includes_some_keywords():
     assert save_to_pg(df, keywords_table, conn) == 1
 
     # check the value is well existing
-    result_before_update = get_keyword(primary_key)
     session = get_db_session(conn)
+    result_before_update = get_keyword(primary_key, session)
     update_keywords(session, batch_size=50, start_date="2024-01-01", end_date="2024-01-30", stop_word_keyword_only=True)
-    result_after_update = get_keyword(primary_key)
+    result_after_update = get_keyword(primary_key, session)
 
     new_theme, new_keywords_with_timestamp, new_value \
         ,number_of_changement_climatique_constat \
@@ -904,7 +901,7 @@ def test_update_only_keywords_that_includes_some_keywords():
         ,number_of_biodiversite_causes_no_hrfp \
         ,number_of_biodiversite_consequences_no_hrfp \
         ,number_of_biodiversite_solutions_no_hrfp = get_themes_keywords_duration(plaintext, srt, start)
-
+    
     assert result_after_update.id == result_before_update.id
 
     # theme
@@ -920,7 +917,6 @@ def test_update_only_keywords_that_includes_some_keywords():
     # number_of_keywords
     assert new_value == number_of_changement_climatique_constat + number_of_adaptation_climatique_solutions_directes
     assert result_after_update.number_of_keywords == new_value
-    assert result_before_update.number_of_keywords == wrong_value
 
     # number_of_changement_climatique_constat
     assert number_of_changement_climatique_constat == 2
@@ -943,24 +939,18 @@ def test_update_only_keywords_that_includes_some_keywords():
     assert number_of_biodiversite_consequences == 0
     assert number_of_biodiversite_solutions_directes == 0
 
-    # program - only when UPDATE_PROGRAM_ONLY for speed issues
-    # assert result_after_update.channel_program == "1245 le mag"
-    # assert result_after_update.channel_program_type == "Information - Magazine"
-
     #channel_title
     assert result_after_update.channel_title == "M6"
 
     # number_of_keywords_climat
     conn.dispose()
+    session.close()
     assert result_after_update.number_of_keywords_climat == number_of_keywords_climat
     
-
-
-
 def test_update_nothing_because_no_keywords_are_included():
     conn = connect_to_db()
-    drop_tables()
-    create_tables()
+    session = get_db_session(conn)
+    empty_tables(session)
         # save some stop words
     stop_word_to_save = [
             {
@@ -1032,9 +1022,9 @@ def test_update_nothing_because_no_keywords_are_included():
     assert save_to_pg(df, keywords_table, conn) == 1
 
     # check the value is well existing
-    result_before_update = get_keyword(primary_key)
     session = get_db_session(conn)
     result = update_keywords(session, batch_size=50, start_date="2024-01-01", end_date="2024-01-30", stop_word_keyword_only=True)
     conn.dispose()
+    session.close()
     assert result == 0 # it means nothing to update
     


### PR DESCRIPTION
Updating all rows can waste resources, the goal is to aim only rows containing our targetted keywords (stop words/new keywords)

Results wanted : 
* faster execution
* cheaper execution

```
* STOP_WORD_KEYWORD_ONLY: boolean, default to False. If true will only update rows whose plaintext match top stop words' keyword. It uses to speed up update.
```