### PR TITLE
feat(api-import): add security nets to catch up delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,10 @@ docker compose up mediatree
 ### Based on time
 If our media perimeter evolves, we have to reimport it all using env variable `START_DATE` like in docker compose (epoch second format : 1705409797). By default, it will import 1 day, you can modify it with `NUMBER_OF_PREVIOUS_DAYS` (integer).
 
-Otherwise, default is yesterday midnight date (default cron job)
+Otherwise, default is yesterday midnight date (default cron job).
+
+#### Production safety nets
+As Scaleway Serverless service can be down, if some dates are missing until today, it will start back from the latest date saved until today.
 
 **As pandas to_sql does not enable upsert (update/insert)**, if we want to update already saved rows, we have to delete first the rows and then start the program with `START_DATE` :
 ```
@@ -396,7 +399,7 @@ For a security nets, we have configured at data pipeline from Mediatree API to S
 
 Env variable used :
 * START_DATE (integer) (unixtimestamp such as mediatree service)
-* NUMBER_OF_PREVIOUS_DAYS (integer): default 7 days
+* NUMBER_OF_PREVIOUS_DAYS (integer): default 7 days to check if something missing
 * CHANNEL: (such as mediatree service)
 * BUCKET : Scaleway Access key
 * BUCKET_SECRET : Scaleway Secret key

--- a/quotaclimat/data_processing/mediatree/api_import_utils/db.py
+++ b/quotaclimat/data_processing/mediatree/api_import_utils/db.py
@@ -1,0 +1,48 @@
+from datetime import date
+import logging
+from typing import Tuple
+from quotaclimat.data_processing.mediatree.utils import *
+from quotaclimat.data_processing.mediatree.config import *
+from postgres.schemas.models import Keywords
+from sqlalchemy.orm import Session
+from sqlalchemy import Select, select, func, cast, Date, Integer, text
+from typing import NamedTuple
+
+class KeywordLastStats(NamedTuple):
+    last_day_saved: date
+    number_of_previous_days_from_yesterday: int
+
+# Security nets to catch up delays from production servers errors
+def get_last_date_and_number_of_delay_saved_in_keywords(session: Session) -> KeywordLastStats:
+    logging.debug(f"get_last_date_and_number_of_delay_saved_in_keywords")
+    try:
+        source_subquery = (
+            select(
+                Keywords.start.label("start"),
+                cast(
+                    func.extract(
+                        "day",
+                        func.date_trunc("day", (func.now() - text("INTERVAL '1 day'"))) - func.date_trunc("day", Keywords.start),
+                    ),
+                    Integer,
+                ).label("previous_days"),
+            )
+            .select_from(Keywords)
+            .where(
+                Keywords.start >= func.now() - text("INTERVAL '30 days'")
+            )
+            .subquery("source")
+        )
+
+        statement: Select[Tuple[date, int]] = (
+            select(
+                func.max(cast(source_subquery.c.start, Date)).label("last_day_saved"),
+                func.min(source_subquery.c.previous_days).label("number_of_previous_days_from_yesterday"),
+            )
+        )
+
+        result = session.execute(statement).fetchone()
+        return KeywordLastStats(result[0], result[1])
+    except Exception as err:
+            logging.error("get_top_keywords_by_channel crash (%s) %s" % (type(err).__name__, err))
+            raise err

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -288,7 +288,10 @@ def update_keyword_row(session: Session,
         )
     else:
         logging.warning(f"Matching themes is empty - deleting row {keyword_id}")
-        session.query(Keywords).filter(Keywords.id == keyword_id).delete()
+        delete_keywords_id(session, keyword_id)
+
+def delete_keywords_id(session, id):
+    session.query(Keywords).filter(Keywords.id == id).delete()
 
 def update_keyword_row_program(session: Session, 
                        keyword_id: int,

--- a/quotaclimat/data_processing/mediatree/utils.py
+++ b/quotaclimat/data_processing/mediatree/utils.py
@@ -109,9 +109,12 @@ def get_start_end_date_env_variable_with_default(start_date:int, minus_days:int=
 # Get range of 2 date by week from start to end
 def get_date_range(start_date_to_query, end_epoch, minus_days:int=1):
     if end_epoch is not None:
-        logging.info(f"Getting date range from {pd.to_datetime(start_date_to_query, unit='s').normalize()} - {pd.to_datetime(end_epoch, unit='s').normalize()}")
-        range = pd.date_range( pd.to_datetime(end_epoch, unit='s').normalize(),
-                              pd.to_datetime(start_date_to_query, unit='s').normalize(),
+        logging.info(f"Getting date range from {pd.to_datetime(start_date_to_query, unit='s').normalize()}\
+                      - {pd.to_datetime(end_epoch, unit='s').normalize()}")
+        
+        range = pd.date_range( \
+                                pd.to_datetime(end_epoch, unit='s').normalize(),
+                                pd.to_datetime(start_date_to_query, unit='s').normalize(),
                               freq="D")
 
         logging.info(f"Date range: {range} \n {start_date_to_query} until {end_epoch}")
@@ -147,3 +150,4 @@ def get_last_X_days(days, from_date = None) -> datetime:
     start_date = end_date - timedelta(days=days)
     logging.debug(f"start_date: {start_date} end_date: {end_date}")
     return start_date
+

--- a/test/mediatree/test_mediatree_queries.py
+++ b/test/mediatree/test_mediatree_queries.py
@@ -1,0 +1,59 @@
+import logging
+
+from quotaclimat.data_processing.mediatree.stop_word.main import *
+from postgres.schemas.models import get_db_session, connect_to_db, drop_tables
+from quotaclimat.data_processing.mediatree.api_import_utils.db import *
+from postgres.insert_data import save_to_pg
+from postgres.schemas.models import create_tables, get_db_session, get_keyword, connect_to_db, drop_tables, empty_tables,keywords_table
+from datetime import date
+from quotaclimat.data_processing.mediatree.update_pg_keywords import *
+
+conn = connect_to_db()
+session = get_db_session(conn)
+
+create_tables()
+
+# TODO test me
+def test_mediatree_get_last_date_and_number_of_delay_saved_in_keywords():
+        conn = connect_to_db()
+        session = get_db_session(conn)
+        start = pd.to_datetime("2025-02-09 12:18:54", utc=True).tz_convert('Europe/Paris')
+        wrong_value = 1
+        pk = "delete_me"
+        df = pd.DataFrame([{
+        "id" : pk,
+        "start": start,
+        "plaintext": "test",
+        "channel_name": "test",
+        "channel_radio": False,
+        "theme":[],
+        "keywords_with_timestamp": [],
+        "srt": [],
+        "number_of_keywords": wrong_value, # wrong data to reapply our custom logic for "new_value"
+        "number_of_changement_climatique_constat":  wrong_value,
+        "number_of_changement_climatique_causes_directes":  wrong_value,
+        "number_of_changement_climatique_consequences":  wrong_value,
+        "number_of_attenuation_climatique_solutions_directes":  wrong_value,
+        "number_of_adaptation_climatique_solutions_directes":  wrong_value,
+        "number_of_ressources":  wrong_value,
+        "number_of_ressources_solutions":  wrong_value,
+        "number_of_biodiversite_concepts_generaux":  wrong_value,
+        "number_of_biodiversite_causes_directes":  wrong_value,
+        "number_of_biodiversite_consequences":  wrong_value,
+        "number_of_biodiversite_solutions_directes" : wrong_value,
+        "channel_program_type": "to change",
+        "channel_program":"to change"
+        ,"channel_title":"channel_title"
+        ,"number_of_keywords_climat": wrong_value
+        ,"number_of_keywords_biodiversite": wrong_value
+        ,"number_of_keywords_ressources": wrong_value
+        }])
+        # TODO insert dummy value
+        save_to_pg(df, keywords_table, conn)
+
+        keywordStats = get_last_date_and_number_of_delay_saved_in_keywords(session)
+        expected_max_date = KeywordLastStats(date(2025, 1, 26), 2)
+       
+        assert expected_max_date.last_day_saved == keywordStats.last_day_saved
+        assert keywordStats.number_of_previous_days_from_yesterday > 1
+        # delete_keywords_id(session, pk)

--- a/test/mediatree/test_mediatree_queries.py
+++ b/test/mediatree/test_mediatree_queries.py
@@ -17,7 +17,7 @@ create_tables()
 def test_mediatree_get_last_date_and_number_of_delay_saved_in_keywords():
         conn = connect_to_db()
         session = get_db_session(conn)
-        start = pd.to_datetime("2025-02-09 12:18:54", utc=True).tz_convert('Europe/Paris')
+        start = pd.to_datetime("2025-01-26 12:18:54", utc=True).tz_convert('Europe/Paris')
         wrong_value = 1
         pk = "delete_me"
         df = pd.DataFrame([{
@@ -56,4 +56,4 @@ def test_mediatree_get_last_date_and_number_of_delay_saved_in_keywords():
        
         assert expected_max_date.last_day_saved == keywordStats.last_day_saved
         assert keywordStats.number_of_previous_days_from_yesterday > 1
-        # delete_keywords_id(session, pk)
+        delete_keywords_id(session, pk)

--- a/test/sitemap/test_main_import_api.py
+++ b/test/sitemap/test_main_import_api.py
@@ -33,7 +33,6 @@ def insert_mediatree_json(conn, json_file_path='test/sitemap/mediatree.json'):
         
         return len(df)
 
-
 def insert_stop_word(conn):
        logging.info("test saving stop words")
        to_save = []

--- a/test/sitemap/test_update_pg_keywords.py
+++ b/test/sitemap/test_update_pg_keywords.py
@@ -4,7 +4,7 @@ from quotaclimat.data_processing.mediatree.update_pg_keywords import *
 
 from quotaclimat.data_ingestion.scrap_sitemap import (get_consistent_hash)
 
-from postgres.schemas.models import create_tables, get_db_session, get_keyword, connect_to_db, drop_tables, empty_tables
+from postgres.schemas.models import create_tables, get_db_session, get_keyword, connect_to_db, drop_tables, empty_tables,keywords_table
 from postgres.insert_data import save_to_pg
 from quotaclimat.data_processing.mediatree.detect_keywords import *
 import pandas as pd


### PR DESCRIPTION
# Production safety nets
As Scaleway Serverless service can be down, if some dates are missing until today, it will start back from the latest date saved until today.

In case the production goes down for several days, it will catch up automatically the delay instead of starting manual importing jobs
