### PR TITLE
fix: start date for delay detection

### DIFF
--- a/quotaclimat/data_processing/mediatree/api_import_utils/db.py
+++ b/quotaclimat/data_processing/mediatree/api_import_utils/db.py
@@ -46,3 +46,9 @@ def get_last_date_and_number_of_delay_saved_in_keywords(session: Session) -> Key
     except Exception as err:
             logging.error("get_top_keywords_by_channel crash (%s) %s" % (type(err).__name__, err))
             raise err
+    
+def get_delay_date(lastSavedKeywordsDate: KeywordLastStats, normal_delay_in_days: int = 1):
+    logging.warning(f"Delay detected : {lastSavedKeywordsDate.number_of_previous_days_from_yesterday } days, it should be {normal_delay_in_days} day")
+    default_start_date = get_epoch_from_datetime(datetime(lastSavedKeywordsDate.last_day_saved.year,lastSavedKeywordsDate.last_day_saved.month,lastSavedKeywordsDate.last_day_saved.day))
+    default_number_of_previous_days = lastSavedKeywordsDate.number_of_previous_days_from_yesterday
+    return default_start_date, default_number_of_previous_days

--- a/test/mediatree/test_mediatree_queries.py
+++ b/test/mediatree/test_mediatree_queries.py
@@ -56,3 +56,12 @@ def test_mediatree_get_last_date_and_number_of_delay_saved_in_keywords():
         assert expected_max_date.last_day_saved == keywordStats.last_day_saved
         assert keywordStats.number_of_previous_days_from_yesterday > 1
         delete_keywords_id(session, pk)
+
+
+def test_get_delay_date():
+        unixtimestamp_2025_01_26 = 1737846000
+        expected_max_date = KeywordLastStats(date(2025, 1, 26), 2)
+        default_start_date, default_number_of_previous_days = get_delay_date(expected_max_date, normal_delay_in_days=1)
+
+        assert default_start_date == unixtimestamp_2025_01_26
+        assert default_number_of_previous_days == 2


### PR DESCRIPTION
Fix: delay detection was inverted, this fixes it by starting from day of execution minus the number of days of delay