### PR TITLE
perf: add FILTER_DAYS_STOP_WORD to get only the last stop words to speed up query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
-          COMPARE_DURATION: "true"
 
   stop_word:
     needs: build
@@ -140,7 +139,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
-          COMPARE_DURATION: "true"
 
 
   test_everything_else:
@@ -199,7 +197,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
-          COMPARE_DURATION: "true"
 
       - name: pytest dbt models
         run: |

--- a/README.md
+++ b/README.md
@@ -417,7 +417,8 @@ Env variables used :
 * NUMBER_OF_PREVIOUS_DAYS (integer): default 7 days
 * MIN_REPETITION (integer) : default 15 - Number of minimum repetition of a stop word
 * CONTEXT_TOTAL_LENGTH (integer) : default 80 - the length of the advertising context (sentence) saved
-
+* FILTER_DAYS_STOP_WORD (integer): default 30 - number of days to filter the last stop words saved from - to speed up update execution
+ 
 ## Remove a stop word
 To remove a false positive, we set to false the `validated` attribute :
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       POSTGRES_HOST: postgres_db
       POSTGRES_PORT: 5432
       MODIN_ENGINE: ray
-      COMPARE_DURATION: "true"
     tty: true # colorize terminal
     volumes:
       - ./quotaclimat/:/app/quotaclimat/
@@ -49,7 +48,6 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_HOST: postgres_db
       POSTGRES_PORT: 5432
-      COMPARE_DURATION: "true"
       MODIN_ENGINE: ray
       MEDIATREE_USER : /run/secrets/username_api
       MEDIATREE_PASSWORD: /run/secrets/pwd_api
@@ -196,7 +194,6 @@ services:
       PORT_HS: 5050 # healthcheck
       HEALTHCHECK_SERVER: "0.0.0.0"
       # SENTRY_DSN: prod_only
-      # COMPARE_DURATION: "true"
       # UPDATE: "true" # to batch update PG 
       #UPDATE_PROGRAM_ONLY: "true" # to batch update PG but only channel with program
       # START_DATE_UPDATE: "2024-02-01" # to batch update PG from a date

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -84,10 +84,10 @@ def get_channels():
 
     return channels
 
-def get_stop_words(session, validated_only=True, context_only=True) -> list[Stop_Word]:
+def get_stop_words(session, validated_only=True, context_only=True, filter_days: int = None) -> list[Stop_Word]:
     logging.info("Getting Stop words...")
     try:
-        stop_words = get_all_stop_word(session, validated_only=validated_only)
+        stop_words = get_all_stop_word(session, validated_only=validated_only, filter_days=filter_days)
         if(context_only):
             result = list(map(lambda stop: stop.context, stop_words))
         else:

--- a/quotaclimat/data_processing/mediatree/stop_word/main.py
+++ b/quotaclimat/data_processing/mediatree/stop_word/main.py
@@ -43,7 +43,7 @@ def is_already_known_stop_word(stop_words: list, context: str) -> bool:
         
     return False
 
-def get_all_stop_word(session: Session, offset: int = 0, batch_size: int = 50000, validated_only = True) -> list:
+def get_all_stop_word(session: Session, offset: int = 0, batch_size: int = 50000, validated_only = True, filter_days: int = None) -> list:
     logging.debug(f"Getting {batch_size} elements from offset {offset}")
 
     statement = select(
@@ -63,6 +63,11 @@ def get_all_stop_word(session: Session, offset: int = 0, batch_size: int = 50000
 
     if validated_only:
             statement = statement.filter(Stop_Word.validated.is_not(False))
+
+    if filter_days is not None:
+        logging.info(f"Getting last {filter_days} days of stop words only for performance execution")
+        date_threshold = datetime.utcnow() - timedelta(days=filter_days)
+        statement = statement.filter(Stop_Word.created_at >= date_threshold)
 
     return session.execute(statement).fetchall()
 

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -3,7 +3,7 @@ import requests
 import modin.pandas as pd
 
 import logging
-
+import os
 from sqlalchemy.orm import Session
 from postgres.schemas.models import Keywords, Stop_Word
 from quotaclimat.data_processing.mediatree.detect_keywords import *
@@ -34,8 +34,9 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
                     end_date: str = "2023-04-30", channel: str = "", empty_program_only=False, \
                         stop_word_keyword_only = False) -> list:
     df_programs = get_programs()
-
-    stop_words_objects = get_stop_words(session, validated_only=True, context_only=False)
+    filter_days_stop_word = int(os.environ.get("FILTER_DAYS_STOP_WORD", 30))
+    logging.info(f"FILTER_DAYS_STOP_WORD is used to get only last {filter_days_stop_word} days of new stop words - to improve update speed")
+    stop_words_objects = get_stop_words(session, validated_only=True, context_only=False, filter_days=filter_days_stop_word)
     stop_words = list(map(lambda stop: stop.context, stop_words_objects))
     top_keyword_of_stop_words = get_top_keyword_of_stop_words(stop_word_keyword_only, stop_words_objects=stop_words_objects)
 

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -120,7 +120,7 @@ def test_get_channels():
     if(os.environ.get("ENV") == "docker"):
         assert get_channels() == ["france2"] # default for docker compose config
     else:
-        assert get_channels() == ["tf1", "france2", "fr3-idf", "m6", "arte", "d8", "bfmtv", "lci", "franceinfotv", "itele",
+        assert get_channels() == ["tf1", "france2", "fr3-idf", "m6", "arte", "bfmtv", "lci", "franceinfotv", "itele",
         "europe1", "france-culture", "france-inter", "sud-radio", "rmc", "rtl", "france24", "france-info", "rfi"]
 
 def test_save_to_pg_keyword_normal():

--- a/test/sitemap/test_update_pg_keywords.py
+++ b/test/sitemap/test_update_pg_keywords.py
@@ -806,9 +806,9 @@ def test_update_only_keywords_that_includes_some_keywords():
                 "id": "test1",
                 "keyword": "conditions de vie sur terre",
                 "channel_title": "France 2",
-                "context": " avait promis de lancer un plan de conditions de vie sur terre euh hélas pas pu climat tout s' est pa",
+                "context": plaintext_stop_word,
                 "count": 20,
-                "id" : get_consistent_hash(" avait promis de lancer un plan de replantation euh hélas pas pu climat tout s' est pa"),
+                "id" : get_consistent_hash(plaintext_stop_word),
             },
             {
                 "keyword_id": "fake_id",
@@ -842,7 +842,7 @@ def test_update_only_keywords_that_includes_some_keywords():
         "number_of_changement_climatique_consequences":  wrong_value,
         "number_of_attenuation_climatique_solutions_directes":  wrong_value,
         "number_of_adaptation_climatique_solutions_directes":  wrong_value,
-        "number_of_ressources":  wrong_value,
+        "number_of_ressources":  2,
         "number_of_ressources_solutions":  wrong_value,
         "number_of_biodiversite_concepts_generaux":  wrong_value,
         "number_of_biodiversite_causes_directes":  wrong_value,
@@ -905,8 +905,9 @@ def test_update_only_keywords_that_includes_some_keywords():
     assert result_after_update.id == result_before_update.id
 
     # theme
-    assert set(new_theme) == set(["adaptation_climatique_solutions",  "changement_climatique_constat"])
-    assert set(result_after_update.theme) == set(["adaptation_climatique_solutions", "changement_climatique_constat"])
+    expected_themes = set(["adaptation_climatique_solutions",  "changement_climatique_constat"])
+    assert set(new_theme) == expected_themes
+    assert set(result_after_update.theme) == expected_themes
         
     # keywords_with_timestamp
     assert len(result_after_update.keywords_with_timestamp) == len(new_keywords_with_timestamp)


### PR DESCRIPTION
FILTER_DAYS_STOP_WORD: default to 30 (days)

for update jobs after new stop words are added