### PR TITLE
fix: save api data to specific timezone, default to europe/paris

### DIFF
--- a/quotaclimat/data_processing/mediatree/channel_program.py
+++ b/quotaclimat/data_processing/mediatree/channel_program.py
@@ -110,7 +110,7 @@ def get_matching_program_hour(df_program: pd.DataFrame, start_time: pd.Timestamp
         return matching_rows
     
 def get_matching_program_weekday(df_program: pd.DataFrame, start_time: pd.Timestamp, channel_name: str):
-    logging.info(f"get_matching_program_weekday {start_time} {channel_name}")
+    logging.debug(f"get_matching_program_weekday {start_time} {channel_name}")
 
     start_weekday = get_day_of_week(start_time)
     logging.debug(f"start_weekday {start_weekday}")

--- a/quotaclimat/data_processing/mediatree/detect_keywords.py
+++ b/quotaclimat/data_processing/mediatree/detect_keywords.py
@@ -355,6 +355,11 @@ def filter_and_tag_by_theme(df: pd.DataFrame, stop_words: list[str] = []) -> pd.
 
 def add_primary_key(row):
     try:
+
+        if str(row['start'].tzinfo) == 'Europe/Paris':
+            # legacy
+            logging.info("PK must be UTC - Timezone is Europe/Paris, converting to UTC")
+            row['start'] = row['start'].tz_convert('UTC')
         hash_id = get_consistent_hash(str(row["start"]) + row["channel_name"])
         return hash_id
 

--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -86,7 +86,9 @@ def parse_reponse_subtitle(response_sub, channel = None, channel_program = "", c
             logging.debug("Schema from API before formatting :\n%s", new_df.dtypes)
             pd.set_option('display.max_columns', None)
             logging.debug("setting timestamp")
-            new_df['timestamp'] = new_df.apply(lambda x: pd.to_datetime(x['start'], unit='s', utc=True), axis=1)
+
+            timezone = 'Europe/Paris'
+            new_df['timestamp'] = new_df.apply(lambda x: pd.to_datetime(x['start'], unit='s',utc=True).tz_convert(timezone), axis=1)
             logging.debug("timestamp was set")
 
             logging.debug("droping start column")

--- a/quotaclimat/data_processing/mediatree/s3/s3_utils.py
+++ b/quotaclimat/data_processing/mediatree/s3/s3_utils.py
@@ -77,8 +77,11 @@ def read_folder_from_s3(date, channel: str):
                                     "secret": SECRET_KEY,
                                     "endpoint_url": ENDPOINT_URL,
                                 })
+    
+    if str(df['start'].dt.tz) == 'UTC':
+        logging.warning(f"Timezone is UTC, converting to Europe/Paris")
+        df['start'] = df['start'].dt.tz_convert('Europe/Paris')
 
-    logging.info(f"read {len(df)} rows from S3")
     return df
 
 

--- a/test/sitemap/test_mediatree.py
+++ b/test/sitemap/test_mediatree.py
@@ -111,7 +111,7 @@ def test_parse_reponse_subtitle():
         "program_metadata_id" : None,
     }])
 
-    expected_result['start'] = pd.to_datetime(expected_result['start'], unit='s').dt.tz_localize('UTC')
+    expected_result['start'] = pd.to_datetime(expected_result['start'], unit='s').dt.tz_localize('UTC').dt.tz_convert('Europe/Paris')
     df = parse_reponse_subtitle(json_response, channel = None, channel_program = channel_program, channel_program_type = "")
     debug_df(df)
 
@@ -167,7 +167,7 @@ def test_save_to_pg_keyword_normal():
         ,"number_of_keywords": 1
     }])
 
-    df['start'] = pd.to_datetime(df['start'], unit='ms').dt.tz_localize('UTC')#.dt.tz_convert('Europe/Paris')
+    df['start'] = pd.to_datetime(df['start'], unit='ms').dt.tz_localize('UTC').dt.tz_convert('Europe/Paris')
     assert save_to_pg(df, keywords_table, conn) == 1
 
     # check the value is well existing

--- a/test/stop_word/test_stop_word.py
+++ b/test/stop_word/test_stop_word.py
@@ -157,7 +157,7 @@ def test_stop_word_get_all_repetitive_context_advertising_for_a_keyword_not_enou
 def test_stop_word_get_repetitive_context_advertising():
         conn = connect_to_db()
         session = get_db_session(conn)
-        start_date = datetime(2025, 1, 14, 15, 29, 59, 329453, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris'))
+        start_date = datetime(2025, 1, 14, 15, 29, 59, 329453, tzinfo=zoneinfo.ZoneInfo(key='UTC'))
         top_keywords = pd.DataFrame(
         [
             {


### PR DESCRIPTION
Save using the right timezone (Europe/Paris) for now, instead of UTC