### PR TITLE
fix: dictionary table boolean value should have being compared

### DIFF
--- a/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
+++ b/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
@@ -21,13 +21,23 @@ SELECT
     d.categories,
     d.themes,
     d.language,
-    -- kw ->> 'theme' AS theme, -- LEGACY replaces with themes
-    -- COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal') AS category, -- LEGACY replaces with categories
+
+    -- Crise type selon le thème --> Legacy with added dictionary join on 11/04/2025
+    CASE
+        WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
+        WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
+        WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
+        ELSE 'Autre'
+    END AS crise_type,
+
+    kw ->> 'theme' AS theme,
+    COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal') AS category,
     kw ->> 'keyword' AS keyword,
+
     COUNT(*) AS count
 
 FROM public.keywords k
-LEFT JOIN public.program_metadata pm  -- TODO: join on program_metadata_id
+LEFT JOIN public.program_metadata pm 
     ON k.channel_program = pm.channel_program 
     AND k.channel_name = pm.channel_name
     AND (
@@ -63,10 +73,17 @@ GROUP BY
     d.categories,
     d.themes,
     d.language,
-    -- kw ->> 'theme', -- LEGACY replaces with themes
-    -- COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal'),  -- LEGACY replaces with categories
+    CASE
+        WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
+        WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
+        WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
+        ELSE 'Autre'
+    END,
+    kw ->> 'theme',
+    COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal'),
     kw ->> 'keyword'
 
 ORDER BY
     pm.channel_title,
-    week
+    week,
+    crise_type

--- a/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
+++ b/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
@@ -21,23 +21,13 @@ SELECT
     d.categories,
     d.themes,
     d.language,
-
-    -- Crise type selon le thème --> Legacy with added dictionary join on 11/04/2025
-    CASE
-        WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
-        WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
-        WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
-        ELSE 'Autre'
-    END AS crise_type,
-
-    kw ->> 'theme' AS theme,
-    COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal') AS category,
+    -- kw ->> 'theme' AS theme, -- LEGACY replaces with themes
+    -- COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal') AS category, -- LEGACY replaces with categories
     kw ->> 'keyword' AS keyword,
-
     COUNT(*) AS count
 
 FROM public.keywords k
-LEFT JOIN public.program_metadata pm 
+LEFT JOIN public.program_metadata pm  -- TODO: join on program_metadata_id
     ON k.channel_program = pm.channel_program 
     AND k.channel_name = pm.channel_name
     AND (
@@ -73,17 +63,10 @@ GROUP BY
     d.categories,
     d.themes,
     d.language,
-    CASE
-        WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
-        WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
-        WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
-        ELSE 'Autre'
-    END,
-    kw ->> 'theme',
-    COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal'),
+    -- kw ->> 'theme', -- LEGACY replaces with themes
+    -- COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal'),  -- LEGACY replaces with categories
     kw ->> 'keyword'
 
 ORDER BY
     pm.channel_title,
-    week,
-    crise_type
+    week

--- a/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
+++ b/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
@@ -89,13 +89,13 @@ def test_core_query_thematics_keywords_count(db_connection):
     count = cur.fetchone()[0]
     cur.close()
 
-    assert count == 108, "count error"
+    assert count == 60, "count error"
 
 def test_core_query_thematics_keywords_values(db_connection):
 
     with db_connection.cursor() as cur:
         cur.execute("""
-            SELECT channel_title, week, crise_type, theme, category, keyword, count,
+            SELECT channel_title, week, keyword, count,
             high_risk_of_false_positive,
             solution,
             consequence,
@@ -118,11 +118,8 @@ def test_core_query_thematics_keywords_values(db_connection):
         expected=   (
         'TF1',
         datetime.date(2025, 1, 27),
-        'Crise climatique',
-        'changement_climatique_constat',
-        'Transversal',
         'eau',
-        4,
+        6,
         True,
         False,
         False,

--- a/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
+++ b/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
@@ -128,13 +128,12 @@ def test_core_query_thematics_keywords_values(db_connection):
         False,
         False,
         True,
-        False,
-        False,
+        True,
+        True,
         True,
         False,
         None,
-        '["changement_climatique_constat_indirectes" '
-        '"biodiversite_concepts_generaux_indirectes"]',
+        '{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}',
         'fr')
         
         assert row == expected, f"Unexpected values: {row}"

--- a/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
+++ b/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
@@ -95,7 +95,7 @@ def test_core_query_thematics_keywords_values(db_connection):
 
     with db_connection.cursor() as cur:
         cur.execute("""
-            SELECT channel_title, week, theme, category, keyword, count,
+            SELECT channel_title, week, crise_type, theme, category, keyword, count,
             high_risk_of_false_positive,
             solution,
             consequence,
@@ -118,6 +118,7 @@ def test_core_query_thematics_keywords_values(db_connection):
         expected=   (
         'TF1',
         datetime.date(2025, 1, 27),
+        'Crise climatique',
         'changement_climatique_constat',
         'Transversal',
         'eau',

--- a/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
+++ b/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
@@ -89,13 +89,13 @@ def test_core_query_thematics_keywords_count(db_connection):
     count = cur.fetchone()[0]
     cur.close()
 
-    assert count == 60, "count error"
+    assert count == 108, "count error"
 
 def test_core_query_thematics_keywords_values(db_connection):
 
     with db_connection.cursor() as cur:
         cur.execute("""
-            SELECT channel_title, week, keyword, count,
+            SELECT channel_title, week, theme, category, keyword, count,
             high_risk_of_false_positive,
             solution,
             consequence,
@@ -109,7 +109,7 @@ def test_core_query_thematics_keywords_values(db_connection):
             themes,
             language
             FROM public.core_query_thematics_keywords
-            WHERE channel_title = 'TF1' AND keyword = 'eau'
+            WHERE channel_title = 'TF1' AND keyword = 'eau' AND theme = 'changement_climatique_constat'
             ORDER BY channel_title DESC
             LIMIT 1
         """)
@@ -118,8 +118,10 @@ def test_core_query_thematics_keywords_values(db_connection):
         expected=   (
         'TF1',
         datetime.date(2025, 1, 27),
+        'changement_climatique_constat',
+        'Transversal',
         'eau',
-        6,
+        4,
         True,
         False,
         False,

--- a/my_dbt_project/seeds/dictionary.csv
+++ b/my_dbt_project/seeds/dictionary.csv
@@ -1,1521 +1,1521 @@
 keyword,high_risk_of_false_positive,solution,consequence,cause,general_concepts,statement,crisis_climate,crisis_biodiversity,crisis_resource,categories,themes,language
-adaptation au changement climatique,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-adaptation au dérèglement climatique,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-adaptation au réchauffement climatique,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-adaptation climatique,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-agro écologie,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-agro écologique,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-agroforesterie,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-agroécologie,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-amélioration des pratiques d’élevage,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-améliorer les systèmes d'alerte et d'évacuation,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-aquaculture durable,false,true,false,false,false,false,true,false,false,"[""Eau"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions_indirectes"" ""adaptation_climatique_solutions""]",fr
-arbre planté,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-bienfaits de la nature,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-bon pour la planète,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-changer nos habitudes alimentaires,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-désalinisation des eaux,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-développement de la planète,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-eaux usées traitées,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions""]",fr
-eco-prêt à taux zéro,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions"" ""adaptation_climatique_solutions""]",fr
-foresterie urbaine,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-forêt urbaine,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-gestion de la ressource en eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-gestion du littoral,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""adaptation_climatique_solutions""]",fr
-gestion durable des forêts,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-gestion durable des terres cultivables,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions_indirectes"" ""adaptation_climatique_solutions""]",fr
-limiter l’érosion des côtes,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-lutte contre le gaspillage d’eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-lutter contre l’érosion,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-mesure environnementale,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-nous adapter à un futur incertain,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-plantant des arbres,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-plantation d'arbres,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-plante des arbres,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-plantent des arbres,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-planter des arbres,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-planté des arbres,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-cyclone,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-déluge,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-prise de conscience environnementale,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-prise de conscience écologique,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-préservation de la nature,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Ecosystème""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-préservation de la ressource en eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-préservation des forêts,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-préserver la forêt,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-préserver la nature,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Ecosystème""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-préserver les forêts,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-prévention des catastrophes naturelles,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-prévention des inondations,false,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions""]",fr
-pêche durable,false,true,false,false,false,false,true,false,false,"[""Eau"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions_indirectes"" ""adaptation_climatique_solutions""]",fr
-reforestation,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-renaturer,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-renforcer les digues,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions""]",fr
-renforcer les dunes,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""adaptation_climatique_solutions""]",fr
-restriction d’eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-retenue collinaire,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-revégétalisation,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-revégétaliser,false,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Sols""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-récupérateur d'eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions""]",fr
-récupérer l'eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-réduction de la demande en eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-réduire l’élevage intensif,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""ressources_solutions"" ""biodiversite_solutions_indirectes"" ""adaptation_climatique_solutions""]",fr
-rénovation des batiments,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions"" ""adaptation_climatique_solutions""]",fr
-rénovation thermique,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions"" ""adaptation_climatique_solutions""]",fr
-réserve d’eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-résistant à la sécheresse,false,true,false,false,false,false,true,false,false,"[""General"" ""Ecosystème""]","[""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-résistante à la sécheresse,false,true,false,false,false,false,true,false,false,"[""General"" ""Ecosystème""]","[""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-réutilisation des eaux usées traitées,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions""]",fr
-sauvegarde de la ressource en eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-tva verte,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-tévéa verte,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-verdir la politique agricole,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-vertueux pour la planète,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-végétalisation,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-végétaliser,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-végétalisé,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-cop27,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-végétalisée,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""adaptation_climatique_solutions""]",fr
-économie d’eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_solutions"" ""adaptation_climatique_solutions""]",fr
-économiser l'eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions""]",fr
-îlot de fraîcheur,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""adaptation_climatique_solutions""]",fr
-aménagement du territoire,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""adaptation_climatique_solutions_indirectes"" ""changement_climatique_causes_indirectes"" ""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-barrage,true,true,false,false,false,false,true,false,false,"[""Eau"" ""Energie"" ""Destruction des habitats""]","[""adaptation_climatique_solutions_indirectes"" ""biodiversite_causes_indirectes"" ""ressources_solutions_indirectes"" ""ressources_indirectes""]",fr
-bon pour la santé,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-changer leurs habitudes,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""ressources_indirectes""]",fr
-changer nos comportements,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-changer nos habitudes,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""ressources_indirectes""]",fr
-digue,true,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions_indirectes""]",fr
-dune,true,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions_indirectes""]",fr
-espace vert,true,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-faire baisser la température,true,true,false,false,false,false,true,false,false,,"[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes""]",fr
-forêt,true,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Forêt""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-gestion de l'eau,true,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions_indirectes""]",fr
-gestion des milieux aquatiques,true,true,false,false,false,false,true,false,false,"[""Eau"" ""Ecosystème""]","[""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-jachère,true,true,false,false,false,false,true,false,false,"[""Sols"" ""Agriculture""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-jardin,true,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-manipuler la terre,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes""]",fr
-mega bassine,true,true,false,false,false,false,true,false,false,"[""Eau""]","[""adaptation_climatique_solutions_indirectes""]",fr
-miscanthus,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""adaptation_climatique_solutions_indirectes""]",fr
-norme,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_indirectes""]",fr
-ombre,true,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""adaptation_climatique_solutions_indirectes""]",fr
-parc,true,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-poumon vert,true,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-pratiques vertueuses,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-sorgho,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""adaptation_climatique_solutions_indirectes""]",fr
-système d'alerte,true,true,false,false,false,false,true,false,false,"[""General""]","[""adaptation_climatique_solutions_indirectes""]",fr
-verdir,true,true,false,false,false,false,true,false,false,,"[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-verdure,true,true,false,false,false,false,true,false,false,,"[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-vertueux,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-ville durable,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes"" ""adaptation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-absorption du carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-agir pour le climat,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-agriculture bio,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-cop28,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-agriculture biologique,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-agriculture de conservation,false,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-agriculture plus verte,false,true,false,false,false,false,true,false,false,"[""Air"" ""Sols"" ""Agriculture"" ""Forêt""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-ajustement carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-amélioration des pratiques d'élevage,false,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions""]",fr
-anti gaspillage,false,true,false,false,false,false,true,false,false,"[""Economie des ressources""]","[""attenuation_climatique_solutions""]",fr
-antigaspi,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-antigaspillage,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-arrêter de prendre l'avion,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-atténuation du changement climatique,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-avihonte,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-avion vert,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-avion à hydrogène,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-baisse des émissions de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-baisse des émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-baisse du trafic aérien,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-bas carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-biocarburant,false,true,false,false,false,false,true,false,false,"[""Transport"" ""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-biochar,false,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions_indirectes""]",fr
-bioclimatique,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-biogaz,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-biomasse,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-bois-énergie,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-bonus climatique,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-bonus écologique,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-bonus-malus écologique,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-borne de recharge,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-bâtiment à énergie positive,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-béton bas carbone,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-captage et stockage,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-capteur de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-capture et séquestration de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-capturer le carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-carburant d'aviation durable,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-carburant d'origine non fossile,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-carburant de synthèse,false,true,false,false,false,false,true,false,false,"[""Transport"" ""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-carburant durable,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-centrale hydroélectrique,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-changer de modèle agricole,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-changer de modèle économique,false,true,false,false,false,false,true,false,false,"[""General"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-ciment de nouvelle génération,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-ciment durable,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-consommation plus responsable,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-consommation responsable,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-contre les émissions de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-crit'air,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-descente énergétique,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-diagnostic de performance energétique,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-diminuer les émissions de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-diminuer les émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-droit environnemental,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-décarbonation,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-décarboner,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-décarboné,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-décarbonée,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-déchet de canne à sucre,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-décroissance énergétique,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-dépolluer,false,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions""]",fr
-dépollution,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-eco-prêt à taux 0,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-ecomobilité,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-efficacité énergétique,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-en consommant moins,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-exploitation raisonnée,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-fin de la vente des voitures thermiques,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-fiscalité environnementale,false,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-flygskam,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-forêt mosaïque,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-geste écologique,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-géothermie,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-honte de prendre l'avion,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-huile de friture usagé,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-hydrogène,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-hydrogène vert,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-hydroélectricité,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-isf climatique,false,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions""]",fr
-isolation par l'extérieur,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-isolation thermique,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-journée de la biodiversité,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-journée de la terre,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-journée mondiale de la vie sauvage,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-leasing électrique,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-limiter la hausse des températures,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-limiter les émissions de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-lutte contre le gaspillage alimentaire,false,true,false,false,false,false,true,false,false,"[""Economie des ressources""]","[""attenuation_climatique_solutions""]",fr
-lutte contre le gaspillage énergétique,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-ma prime rénov,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-maison autonome,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-maison passive,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-malus écologique,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Transport""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-maprimerénov,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-matériaux biosourcés,false,true,false,false,false,false,true,false,false,"[""Economie circulaire"" ""Batiments""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-matériaux plus vertueux,false,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions""]",fr
-matériaux recyclables,false,true,false,false,false,false,true,false,false,"[""Economie circulaire"" ""Batiments""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-matériaux recyclés,false,true,false,false,false,false,true,false,false,"[""Economie circulaire"" ""Batiments""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-mobilité douce,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-mobilité durable,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-moins polluant,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-moins polluer,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-moins prendre l'avion,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-méthanisation,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-méthaniseur,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-net zéro émission,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-objectif climatique,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-panneau solaire,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-panneaux solaires,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-parc photovoltaïque,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-parc éolien,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-photovoltaïque,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-plastique recyclé,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-pollueur payeur,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-prime à la casse,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-produits verts,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""ressources"" ""biodiversite_solutions""]",fr
-protection de la planète,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions""]",fr
-protection des cours d’eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-protection des océans,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""attenuation_climatique_solutions""]",fr
-protection des tourbières,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-protection du vivant,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-puits carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-puits de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-quota de pêche,false,true,false,false,false,false,true,false,false,"[""Eau"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-recyclage,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-recyclant,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-recycler,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-remplacer les énergies fossiles,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-respect de l’environnement,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Ecosystème""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-respectueux de l’environnement,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-restauration des tourbières,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-restauration des zones humides,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-restauration écologique,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-restaurer les tourbières,false,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-réduction de la consommation,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions_indirectes"" ""ressources_solutions""]",fr
-réduction des gaspillages énergétiques,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-réduction des émissions de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-réduction des émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-réduction du cheptel,false,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions""]",fr
-réduction du gaspillage alimentaire,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-réduction du gaspillage énergétique,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-réduire la consommation,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions_indirectes""]",fr
-réduire la consommation d’eau,false,true,false,false,false,false,true,false,false,"[""Eau""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-réduire le cheptel,false,true,false,false,false,false,true,false,false,"[""Air"" ""Eau"" ""Sols"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-réduire le trafic aérien,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-réduire les émissions de carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-réduire les émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-réduire les émissions d’azote,false,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions""]",fr
-réduire sa consommation de viande,false,true,false,false,false,false,true,false,false,"[""Concepts généraux"" ""Agriculture""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-réemploi,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-réseau de chaleur,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-réseaux de chaleur,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-réservoir d'hydrogène,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-sans émettre de co deux,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-sans émettre de co2,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-se débarrasser des énergies fossiles,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions""]",fr
-se décarboner,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-semaine du développement durable,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-sevrage des énergies fossiles,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-sobriété,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-sobriété énergétique,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-société écologique,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-sortie des énergies fossiles,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-sortie du charbon,false,true,false,false,false,false,true,false,false,"[""Air"" ""Métaux et minerais"" ""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-stockage du carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-stockage du carbone dans les sols,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-stockage du co deux,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-stocker le carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-séquestration du carbone,false,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions"" ""biodiversite_concepts_generaux""]",fr
-technologie verte,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-transport décarboné,false,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions""]",fr
-valorisation des déchets,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-ville écologique,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-zfe,false,true,false,false,false,false,true,false,false,"[""Air"" ""Transport""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-zone à faible émission,false,true,false,false,false,false,true,false,false,"[""Air"" ""Transport""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-zéro carbone,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-zéro plastique,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-zéro émission nette,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions""]",fr
-éco conception,false,true,false,false,false,false,true,false,false,"[""Industrie"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-éco geste,false,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-éco organisme,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-éco responsable,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-eau boueuse,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-écoconception,false,true,false,false,false,false,true,false,false,"[""Industrie"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-économie circulaire,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-économie d’énergie,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-économie qui répare,false,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-économiser de l’énergie,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-écoresponsable,false,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions"" ""ressources_solutions""]",fr
-énergie durable,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-énergie renouvelable,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-énergie solaire,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-énergie verte,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-éolien,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-éolienne,false,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions"" ""ressources_solutions""]",fr
-étiquetage unique des aliments,false,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions"" ""biodiversite_solutions""]",fr
-activisme climatique,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-activiste pour le climat,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-agriculture durable,true,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-alternative,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_indirectes""]",fr
-alternative durable,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-approche systémique,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-atténuation,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-bardage en bois,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-biodégradable,true,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-bois d’oeuvre,true,true,false,false,false,false,true,false,false,"[""Forêt"" ""Batiments""]","[""attenuation_climatique_solutions_indirectes"" ""ressources""]",fr
-bonus automobile,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-borne électrique,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-bus,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-bus électrique,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-camion xxl,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-camion électrique,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-centrale nucléaire,true,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions_indirectes""]",fr
-changement de chaudière,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-compostage,true,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-covoiturage,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-déconstruire,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-décroissance,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-désobéissance civile,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-développement durable,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-epr,true,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions""]",fr
-falloir ralentir,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-fret ferroviaire,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-habitude durable,true,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-industrie verte,true,true,false,false,false,false,true,false,false,"[""Industrie"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-intercités,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-isolation,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-isoler la façade,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-isoler les fenêtres,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-label ab,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes""]",fr
-label bio,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes""]",fr
-label hve,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes""]",fr
-label éco,true,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions_indirectes""]",fr
-label écologique,true,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions_indirectes""]",fr
-leasing social,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-ligne tgv,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-made in france,true,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions_indirectes""]",fr
-manifestation pour le climat,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-marche du siècle,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-marche pour le climat,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-marche à pied,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-matériau isolant,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-matériaux isolants,true,true,false,false,false,false,true,false,false,,"[""attenuation_climatique_solutions_indirectes""]",fr
-militant écologiste,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-militante écologiste,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-moins de viande,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes""]",fr
-nucléaire,true,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-pass rail,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-passer à l'électrique,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-permaculture,true,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions""]",fr
-plus durable,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-plus d’oxygène,true,true,false,false,false,false,true,false,false,,"[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-poid lourd électrique,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-polyculture élevage,true,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-pompe à chaleur,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-prairie,true,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-principe de précaution,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes""]",fr
-produire en europe,true,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions_indirectes""]",fr
-préserver,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-recharge,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-relocaliser la production,true,true,false,false,false,false,true,false,false,"[""Industrie""]","[""attenuation_climatique_solutions_indirectes""]",fr
-replantation,true,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-replanter,true,true,false,false,false,false,true,false,false,"[""Ecosystème"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-responsable,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-restreindre,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-eaux boueuses,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-eaux déchainées,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-restriction,true,true,false,false,false,false,true,false,false,"[""General"" ""Concepts généraux""]","[""ressources_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""biodiversite_consequences_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes"" ""attenuation_climatique_solutions_indirectes""]",fr
-réacteur nucléaire,true,true,false,false,false,false,true,false,false,"[""Energie""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-réguler les températures,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-rénovation,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-rénovation énergétique,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-résistance thermique,true,true,false,false,false,false,true,false,false,"[""Batiments""]","[""attenuation_climatique_solutions_indirectes""]",fr
-saf,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-se déplacer en vélo,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-taxe carbone,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-ter,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-tgv,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-train,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-trains régionaux,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-tramway,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-transport collectif,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-transport en commun,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-transport ferroviaire,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-transport fluvial,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-transport maritime,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-tri à la source,true,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Economie circulaire""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions""]",fr
-té heu air,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-tégévé,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-voitures électriques,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-végan,true,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-végane,true,true,false,false,false,false,true,false,false,"[""Agriculture""]","[""attenuation_climatique_solutions_indirectes""]",fr
-végétarien,true,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-végétarienne,true,true,false,false,false,false,true,false,false,"[""Agriculture"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-véhicule électrique,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-vélo,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-zad,true,true,false,false,false,false,true,false,false,"[""Ecosystème""]","[""attenuation_climatique_solutions_indirectes""]",fr
-zadisme,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-zadiste,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-économie de carburant,true,true,false,false,false,false,true,false,false,"[""Transport"" ""Energie""]","[""attenuation_climatique_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-écotaxe,true,true,false,false,false,false,true,false,false,"[""Transport""]","[""attenuation_climatique_solutions_indirectes""]",fr
-éducation au changement climatique,true,true,false,false,false,false,true,false,false,"[""General""]","[""attenuation_climatique_solutions_indirectes""]",fr
-épargne citoyenne,true,true,false,false,false,false,true,false,false,"[""Economie des ressources"" ""Concepts généraux""]","[""attenuation_climatique_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-a69,false,false,false,true,false,false,false,true,false,"[""Transport"" ""Destruction des habitats""]","[""biodiversite_causes"" ""changement_climatique_causes""]",fr
-agribusiness,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-agriculture conventionnelle,false,false,false,true,false,false,false,true,false,"[""Agriculture"" ""General"" ""Eau"" ""Air"" ""Sols""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-agriculture extensive,false,false,false,true,false,false,false,true,false,"[""General"" ""Sols"" ""Agriculture""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-agriculture industrielle,false,false,false,true,false,false,false,true,false,"[""Agriculture"" ""General"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-agriculture intensive,false,false,false,true,false,false,false,true,false,"[""Agriculture"" ""General"" ""Eau"" ""Forêt"" ""Air"" ""Sols""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-artificialisation des milieux naturels,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-cop vingt-sept,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-artificialisation des sols,false,false,false,true,false,false,false,true,false,"[""Eau"" ""Sols"" ""Destruction des habitats""]","[""ressources"" ""biodiversite_causes""]",fr
-assèchement des zones humides,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-braconnage,false,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes""]",fr
-braconnier,false,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes""]",fr
-bétonisation,false,false,false,true,false,false,false,true,false,"[""Eau"" ""Sols"" ""Destruction des habitats""]","[""ressources"" ""biodiversite_causes""]",fr
-bétonner les sols,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-cadmium,false,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes"" ""ressources_indirectes""]",fr
-changement d’usage des terres,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-chlordécone,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-coupe rase,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-destruction de la planète,false,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux"" ""Ecosystème""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-destruction des habitats naturels,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-destruction des milieux naturels,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-disparition des haies,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-décharge sauvage,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Economie circulaire""]","[""ressources"" ""biodiversite_causes""]",fr
-déchet toxique,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-déforestation,false,false,false,true,false,false,false,true,false,"[""General"" ""Ecosystème"" ""Forêt""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-dépôt sauvage,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Economie circulaire""]","[""ressources"" ""biodiversite_causes""]",fr
-engrais azoté,false,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-engrais de synthèse,false,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-engrais phosphaté,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-extractivisme,false,false,false,true,false,false,false,true,false,"[""Concepts généraux"" ""Surexploitation des ressources""]","[""ressources"" ""biodiversite_causes""]",fr
-extractiviste,false,false,false,true,false,false,false,true,false,"[""Concepts généraux"" ""Surexploitation des ressources""]","[""ressources"" ""biodiversite_causes""]",fr
-glyphosate,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-herbicide,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-imperméabilisation des sols,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-intrant chimique,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-marée noire,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-massacre des terres,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-mauvaise nouvelle pour la planète,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes"" ""changement_climatique_causes""]",fr
-micro-plastique,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-microplastique,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-micropolluant,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-multinationale agroalimentaire,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-métaux lourds,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes"" ""ressources_indirectes""]",fr
-nocif pour l'environnement,false,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux""]","[""biodiversite_causes"" ""ressources_solutions"" ""changement_climatique_causes""]",fr
-néonicotinoïde,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-paille en plastique,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-pas très écolo,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes"" ""changement_climatique_causes""]",fr
-perméabilisation des sols,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-perte d’habitats,false,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes""]",fr
-pesticide,false,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-pesticide résiduel,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-pfas,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-pfoa,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-pfos,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-polluant,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""General"" ""Concepts généraux""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-pollueur,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""General""]","[""biodiversite_causes"" ""changement_climatique_causes""]",fr
-cop vingt-six,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-pollution atmosphérique,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes"" ""changement_climatique_consequences""]",fr
-pollution chimique,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Concepts généraux""]","[""ressources"" ""biodiversite_causes""]",fr
-pollution de la mer,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-pollution de l’eau,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-pollution des sols,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-pollution environnementale,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-pollution plastique,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-pollution record,false,false,false,true,false,false,false,true,false,"[""General"" ""Eau"" ""Pollution"" ""Air"" ""Sols""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-pression sur les milieux naturels,false,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes""]",fr
-productivisme,false,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux""]","[""ressources_indirectes"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-productiviste,false,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux""]","[""ressources_indirectes"" ""biodiversite_causes"" ""changement_climatique_causes""]",fr
-produit phytosanitaire,false,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes""]",fr
-ptfe,false,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-pêche industrielle,false,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes""]",fr
-surpêche,false,false,false,true,false,false,false,true,false,"[""Eau"" ""Surexploitation des ressources""]","[""ressources"" ""biodiversite_causes""]",fr
-écocide,false,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux""]","[""ressources"" ""biodiversite_causes"" ""changement_climatique_consequences""]",fr
-épandage,false,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""ressources"" ""biodiversite_causes""]",fr
-étalement urbain,false,false,false,true,false,false,false,true,false,"[""Sols"" ""Destruction des habitats""]","[""ressources"" ""biodiversite_causes""]",fr
-acide,true,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-activité industrielle,true,false,false,true,false,false,false,true,false,"[""General"" ""Eau"" ""Industrie"" ""Forêt"" ""Air"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-agro-industrie,true,false,false,true,false,false,false,true,false,"[""General"" ""Agriculture""]","[""biodiversite_causes_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-agro-industriel,true,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux"" ""Agriculture""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-arsenic,true,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-bouteille en plastique,true,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes_indirectes""]",fr
-bétonner,true,false,false,true,false,false,false,true,false,"[""Sols"" ""Destruction des habitats""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-cancérigène,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Concepts généraux""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-cancérogène,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Concepts généraux""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-capitalisme,true,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux"" ""Economie des ressources""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-commerce illégal d’espèces,true,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes_indirectes""]",fr
-complexe agro-industriel,true,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes_indirectes""]",fr
-déchet,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Economie des ressources"" ""Economie circulaire""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-emballage,true,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes_indirectes""]",fr
-emballage en plastique,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Economie des ressources"" ""Economie circulaire""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-emballage plastique,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Economie des ressources"" ""Economie circulaire""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-feux,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes""]",fr
-feux de forêt,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-fluor,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-fongicide,true,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes_indirectes""]",fr
-forêt brûle,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêt d'algues,true,false,false,true,false,false,false,true,false,"[""Forêt"" ""Espèces exotiques envahissantes""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêt détruit,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêt détruite,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêt ravagé,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêt ravagée,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêts brûlent,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-forêts ont été détruites,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-huile de palme,true,false,false,true,false,false,false,true,false,"[""General""]","[""biodiversite_causes_indirectes""]",fr
-incendie de forêt,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats"" ""Forêt""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-incendies,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes""]",fr
-intrants,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-milieu artificiel,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes_indirectes""]",fr
-mégot,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Concepts généraux""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-nouvelles techniques génomiques,true,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes_indirectes""]",fr
-ogm,true,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes_indirectes""]",fr
-organisme génétiquement modifiée,true,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes_indirectes""]",fr
-perturbateur endocrinien,true,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes_indirectes""]",fr
-plante exotique envahissante,true,false,false,true,false,false,false,true,false,"[""Ecosystème"" ""Espèces exotiques envahissantes""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes""]",fr
-plante exotique invasive,true,false,false,true,false,false,false,true,false,"[""Ecosystème"" ""Espèces exotiques envahissantes""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes""]",fr
-plante exotique très invasive,true,false,false,true,false,false,false,true,false,"[""Ecosystème"" ""Espèces exotiques envahissantes""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes""]",fr
-plastique,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Economie circulaire""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-plomb,true,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-pollue,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""General"" ""Concepts généraux""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-polluer,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""General""]","[""biodiversite_causes_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-pollution,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""General""]","[""biodiversite_causes_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-pollution de l’air,true,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes_indirectes""]",fr
-rejets industriels,true,false,false,true,false,false,false,true,false,"[""Pollution""]","[""biodiversite_causes_indirectes""]",fr
-réchauffement,true,false,false,true,false,false,false,true,false,"[""Changement climatique""]","[""biodiversite_causes_indirectes"" ""changement_climatique_consequences_indirectes""]",fr
-site minier,true,false,false,true,false,false,false,true,false,"[""General"" ""Métaux et minerais""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-solvant,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Eau"" ""Sols"" ""Industrie""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-surconsommation,true,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux""]","[""biodiversite_causes_indirectes"" ""ressources""]",fr
-sécheresse,true,false,false,true,false,false,false,true,false,"[""General"" ""Eau""]","[""biodiversite_causes_indirectes"" ""ressources"" ""changement_climatique_consequences""]",fr
-tourisme de masse,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes_indirectes""]",fr
-toxique,true,false,false,true,false,false,false,true,false,"[""Pollution"" ""Concepts généraux""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-trafic d’espèces,true,false,false,true,false,false,false,true,false,"[""Surexploitation des ressources""]","[""biodiversite_causes_indirectes""]",fr
-urbanisation,true,false,false,true,false,false,false,true,false,"[""Destruction des habitats""]","[""biodiversite_causes_indirectes""]",fr
-urbanisme,true,false,false,true,false,false,false,true,false,"[""General"" ""Concepts généraux"" ""Destruction des habitats""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes"" ""changement_climatique_causes_indirectes""]",fr
-zinc,true,false,false,true,false,false,false,true,false,"[""Air"" ""Pollution"" ""Eau"" ""Sols""]","[""biodiversite_causes_indirectes"" ""ressources_indirectes""]",fr
-accord de kunming,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-accord de kunming-montréal,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-accord de montréal,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-ademe,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources_solutions"" ""changement_climatique_constat""]",fr
-agence de l'eau,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-aire marine protégée,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-amnésie environnementale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-amphibien,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-animaux sauvages,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-anti-écolo,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-arbre remarquable,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-arnica,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-atteinte à la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-bien être animal,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-bien-être animal,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-bien-être de la nature,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-bio capacité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-biocapacité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-bios géo chimique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-bonne nouvelle pour la planète,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources_solutions"" ""changement_climatique_constat""]",fr
-calotte du groenland,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-calotte glacière,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-calotte polaire,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-capacité planétaire,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-chauve-souris,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cigogne,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-coléoptères,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-consommation de plastique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-continuité écologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-convention des nations unies sur la diversité biologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-convention sur la diversité biologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop 15,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop 16,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop de montréal,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop dix sept,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop quinze,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-cop seize,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop sur la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cop15,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-crise de la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-cycles biogéochimiques,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-d'ici 2050,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-destruction de la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-disparition des espèces,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""biodiversite_consequences""]",fr
-diversité biologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-diversité des êtres vivants,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-diversité du vivant,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-déclin du vivant,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-dégradation de l'habitat,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-dégradation des ecosystèmes,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-empreinte biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-empreinte plastique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-enjeu environnemental,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-equilibre dynamique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-espèce animale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-espèce locale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-espèce migratrice,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-espèce végétale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-faune sauvage,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-fertilité des sols,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-flamant rose,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-fne,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-fnh,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-fondation pour la nature et l'homme,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-forêt boréale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-forêt tropicale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-france nature environnement,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-green deal,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-greenpeace,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-gypaète barbu,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-habitat naturel,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-habiter le monde,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""changement_climatique_constat"" ""ressources_indirectes""]",fr
-hot spot de biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-hydrologue,false,false,false,false,true,false,false,true,false,"[""Eau""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-impact environnementale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-interaction avec le vivant,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-intégrité écologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-intérêt environnemental,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources_solutions"" ""changement_climatique_constat""]",fr
-ipbes,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-journée mondiale de l'océan,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-journée mondiale des océans,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-libre évolution,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-lien au vivant,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-lien avec le vivant,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-lieu de ponte,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-ligue de protection des oiseaux,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-mammifère marin,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-mammifère terrestre,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-mangrove,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-milieu d'eau douce,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-milieu forestier,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-milieux naturels,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-mnhn,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-muséum d'histoire naturelle,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-mutation écologique,false,false,false,false,true,false,false,true,false,"[""General"" ""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources_solutions"" ""changement_climatique_constat""]",fr
-mycorhize,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-mésange,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-métabolite,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-nappe phréatique,false,false,false,false,true,false,false,true,false,"[""Eau""]","[""biodiversite_concepts_generaux"" ""ressources""]",fr
-nidification,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-ofb,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-office français de la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-office national des forêts,false,false,false,false,true,false,false,true,false,"[""Forêt""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-pacte vert,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-patrimoine naturel,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-personnalité juridique des éléments naturels,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-photosynthèse,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-plage de ponte,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-plancton,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-planification écologique,false,false,false,false,true,false,false,true,false,"[""General"" ""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources_solutions"" ""changement_climatique_constat""]",fr
-point chaud de biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-politique climatique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-politique environnementale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-pollinisateur,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-polliniser,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-posidonie,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-protocole de montréal,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-relation au vivant,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-ressource planétaire,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-rouge gorge,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-réserve de chasse,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-résilience des écosystèmes,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-santé environnementale,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-sciences de l'environnement,false,false,false,false,true,false,false,true,false,"[""General"" ""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources_solutions"" ""changement_climatique_constat""]",fr
-service rendu par la nature,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-services écosystémiques,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-site de ponte,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-sixième extinction de masse,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-sommet sur la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-spécialiste de la biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-spécialiste des questions environnementales,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-stratégie nationale biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-séquestrer le carbone,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-tortue marine,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-tourbières,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-transition agro écologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-transition agroécologique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux"" ""changement_climatique_constat""]",fr
-transition écologique,false,false,false,false,true,false,false,true,false,"[""General"" ""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-uicn,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-union internationale pour la conservation de la nature,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-ver de terre,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-vison d'europe,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-wwf,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-zone de biodiversité,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-zones humides,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-écologique,false,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_concepts_generaux"" ""ressources"" ""changement_climatique_constat""]",fr
-écosystème aquatique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-écosystème forestier,false,false,false,false,true,false,false,true,false,"[""Forêt""]","[""biodiversite_concepts_generaux"" ""ressources""]",fr
-écosystème marin,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-écosystème montagnard,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-écosystèmes dégradés,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-écosystémique,false,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux""]",fr
-abeille,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-agences régionales de santé,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-agricole,true,false,false,false,true,false,false,true,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-agriculteur,true,false,false,false,true,false,false,true,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-agriculture,true,false,false,false,true,false,false,true,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-agroalimentaire,true,false,false,false,true,false,false,true,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-alimentation,true,false,false,false,true,false,false,true,false,"[""Concepts généraux"" ""Agriculture""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-anguille,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-arbre,true,false,false,false,true,false,false,true,false,"[""Forêt""]","[""ressources_solutions_indirectes"" ""biodiversite_solutions_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-ars,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-autorité de santé,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-bactérie,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-biologiste,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-bloc d’immeubles,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-bocage,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-calotte,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-castor,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-cerf,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-champignon,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-chardonneret,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-chasse,true,false,false,false,true,false,false,true,false,"[""Forêt""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-chasseur,true,false,false,false,true,false,false,true,false,"[""Forêt""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-chevreuil,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-châtaignier,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-chêne,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-civelle,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-corail,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-coraux,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-cours d'eau,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-crise du lien,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-croissance bleue,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-croissance verte,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat"" ""biodiversite_concepts_generaux_indirectes""]",fr
-crustacé,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-dauphin,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-diversité génétique,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-déchetterie,true,false,false,false,true,false,false,true,false,"[""Economie circulaire""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-dégrader,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-désertification,true,false,false,false,true,false,false,true,false,"[""Eau"" ""Sols""]","[""ressources_indirectes"" ""changement_climatique_consequences_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-eau,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-eau douce,true,false,false,false,true,false,false,true,false,"[""Eau""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-environnement,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-environnemental,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-environnementale,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-environnementaux,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-espèce,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-faune,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-flore,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-fourmi,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-frelon,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-genepi,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-guêpe,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-générations futures,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-générations à venir,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-habitat,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-hirondelle,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-humus,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-hérisson,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-hêtre,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-impact négatif,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-impact positif,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-impact sur la santé,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-incinérateur,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-insecte,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-irrigation,true,false,false,false,true,false,false,true,false,"[""Eau"" ""Sols""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-isard,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-izard,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-lac,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-le vivant,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-littoral,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-loup,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-lpo,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-lynx,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-mammifère,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-marais,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-mare,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-marmotte,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-marécage,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-mer,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-micro-organisme,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-microbe,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-milieu humide,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-milieu montagnard,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-ministre de la transition écologique,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-ministère de la transition écologique,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-modèle agricole,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-moineau,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-mollusque,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-montagne,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-moustique,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-nature,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-naturel,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-naturelle,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-nexus,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-non humain,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-océan,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-océanographe,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-oiseau,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-oms,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-one health,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-organisation mondiale de la santé,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-organisme vivant,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-ours,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-ours polaire,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-papillon,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-pelouse,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-pigeon,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-pins,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-planète,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-planétaire,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-poisson,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-pollinisation,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-pression,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-pêche professionnelle,true,false,false,false,true,false,false,true,false,"[""Eau""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-pêcheur,true,false,false,false,true,false,false,true,false,"[""Eau""]","[""ressources_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-renard,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-revue nature,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-rivière,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-récif,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-récif corallien,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-sanglier,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-sapin,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-sargasse,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-saumon,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-sciences du vivant,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-termites,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-terre,true,false,false,false,true,false,false,true,false,"[""Concepts généraux"" ""Sols""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-tortue,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-tourbe,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-truite,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-une seule santé,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-vautour,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-vie sous-marine,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-virus,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-vivant,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-végétaux,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-zone humide,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-écolo,true,false,false,false,true,false,false,true,false,"[""Concepts généraux""]","[""ressources_solutions_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-écologie,true,false,false,false,true,false,false,true,false,"[""Eau""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-écologiste,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-économie bleue,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-économie maritime,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-écosystème,true,false,false,false,true,false,false,true,false,,"[""changement_climatique_constat_indirectes"" ""biodiversite_concepts_generaux_indirectes""]",fr
-écotourisme,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-écrevisse,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-éléphant,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-épicéa,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-étang,true,false,false,false,true,false,false,true,false,,"[""biodiversite_concepts_generaux_indirectes""]",fr
-acidification des océans,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences"" ""changement_climatique_consequences""]",fr
-acidification du milieu marin,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-baisse de production agricole,false,false,false,false,false,false,false,true,false,"[""Eau"" ""Sols""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-baisse des rendements agricoles,false,false,false,false,false,false,false,true,false,"[""Eau"" ""Sols""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-baisse des récoltes,false,false,false,false,false,false,false,true,false,"[""Sols""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-baisse du stockage du carbone dans les sols,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-baleine échouée,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-biodiversité en danger,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-bioérosion,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-bruit routier,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-catastrophe écologique,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-condition dégradée d’habitation,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-crise d'extinction de masse,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-crise environnementale,false,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_constat""]",fr
-dauphin échoué,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-diminution des rendements agricoles,false,false,false,false,false,false,false,true,false,"[""Eau"" ""Sols""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-disparition des forêts,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences"" ""changement_climatique_consequences""]",fr
-disparition des insectes,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-disparition des oiseaux,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-disparition du vivant,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-déclin de la biodiversité,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-dégradation des puits de carbone,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-dégradation des sols,false,false,false,false,false,false,false,true,false,"[""Sols""]","[""biodiversite_consequences"" ""ressources""]",fr
-espèce en voie de disparition,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-espèce envahissante,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-espèce exotique envahissante,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-espèce invasive,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences"" ""changement_climatique_consequences""]",fr
-espèce menacée,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-espèce menacée d’extinction,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-espèce éteinte,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-espèces en danger,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-impact sur l'environnement,false,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-liste rouge de l'uicn,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-liste rouge mondiale des espèces menacées,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-mammifère échoué,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-migration des espèces,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-mortalité des forêts,false,false,false,false,false,false,false,true,false,"[""Forêt""]","[""biodiversite_consequences"" ""ressources""]",fr
-mortalité forestière,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences"" ""changement_climatique_consequences""]",fr
-moustique tigre,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences"" ""changement_climatique_consequences""]",fr
-nature empoisonnée,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-perte agricole,false,false,false,false,false,false,false,true,false,"[""Eau"" ""Sols""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-perte de biodiversité,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-perturbation des habitats,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-perturbation des écosystèmes,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-perturbation du cycle de l’eau,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-pollution sonore,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-polluée,false,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_consequences"" ""ressources""]",fr
-santé végétale,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-sol pollué,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-urgence écologique,false,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_consequences"" ""ressources"" ""changement_climatique_consequences""]",fr
-zoonose,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences"" ""changement_climatique_consequences""]",fr
-zoonotique,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-écosystème dégradé,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-érosion de la biodiversité,false,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences""]",fr
-assécher,true,false,false,false,false,false,false,true,false,"[""Eau""]","[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes"" ""ressources_indirectes""]",fr
-asséché,true,false,false,false,false,false,false,true,false,"[""Eau""]","[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes"" ""ressources_indirectes""]",fr
-asséchée,true,false,false,false,false,false,false,true,false,"[""Eau""]","[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes"" ""ressources_indirectes""]",fr
-cancer,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-chant des oiseaux,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-contaminé,true,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_consequences_indirectes"" ""ressources_indirectes""]",fr
-contaminée,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-dengue,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-dépérissement,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-dévastation,true,false,false,false,false,false,false,true,false,"[""General""]","[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-exposition des salariés,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-extinction,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-les soulèvements de la terre,true,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes"" ""ressources_indirectes""]",fr
-malade,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-maladie,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-maladies infectieuses,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-maladies transmises par des insectes,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-menacées de disparition,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-pathologie,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-pollué,true,false,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_consequences_indirectes"" ""ressources_indirectes""]",fr
-problème sanitaire,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-prolifération des moustiques,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-risque sanitaire,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-santé animale,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-santé humaine,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-sécurité alimentaire,true,false,false,false,false,false,false,true,false,,"[""changement_climatique_consequences_indirectes"" ""biodiversite_consequences_indirectes""]",fr
-échouage,true,false,false,false,false,false,false,true,false,,"[""biodiversite_consequences_indirectes""]",fr
-accueillir la faune,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-agriculture régénératrice,false,true,false,false,false,false,false,true,false,"[""Agriculture""]","[""biodiversite_solutions""]",fr
-aire naturelle protégée,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-aires protégées,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-amoureux de la nature,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-amélioration des pratiques d’élevages,false,true,false,false,false,false,false,true,false,"[""Agriculture""]","[""biodiversite_solutions""]",fr
-barrière végétale,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-bien-être des animaux,false,true,false,false,false,false,false,true,false,"[""Agriculture""]","[""biodiversite_solutions""]",fr
-bioplastique,false,true,false,false,false,false,false,true,false,"[""Economie des ressources"" ""Economie circulaire""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-changement transformateur,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-conservation de la nature,false,true,false,false,false,false,false,true,false,"[""Concepts généraux"" ""Ecosystème""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-conserver la nature,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-corridor écologique,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-droit de l’environnement,false,true,false,false,false,false,false,true,false,"[""General""]","[""biodiversite_solutions""]",fr
-défense de l'environnement,false,true,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""ressources_solutions"" ""biodiversite_solutions"" ""changement_climatique_constat""]",fr
-défense de la nature,false,true,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""ressources_solutions"" ""biodiversite_solutions"" ""changement_climatique_constat""]",fr
-défenseur de l'environnement,false,true,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""ressources_solutions"" ""biodiversite_solutions"" ""changement_climatique_constat""]",fr
-défenseur de la nature,false,true,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""ressources_solutions"" ""biodiversite_solutions"" ""changement_climatique_constat""]",fr
-emballage sans plastique,false,true,false,false,false,false,false,true,false,"[""Economie circulaire""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-espace naturel,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-espèce protégée,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-foncière forestière,false,true,false,false,false,false,false,true,false,"[""Ecosystème"" ""Forêt""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-gestion durable des ressources,false,true,false,false,false,false,false,true,false,"[""Concepts généraux""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-moins de fertilisant,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-nettoyage des fonds marins,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-nettoyage des océans,false,true,false,false,false,false,false,true,false,"[""Eau"" ""Ecosystème""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-paillage naturel,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-pratiques agricoles durables,false,true,false,false,false,false,false,true,false,"[""Agriculture""]","[""biodiversite_solutions""]",fr
-protection de l'environnement,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection de la barrière de corail,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection de la mangrove,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection de la nature,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection des coraux,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection des côtes,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection des espèces,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection des habitats,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-protection des oiseaux,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection des zones côtières,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection des zones humides,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protection du récif corallien,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protéger la nature,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protéger le vivant,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-protéger les habitats,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-préservation d'espèce,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-préservation de la biodiversité,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-préservation des milieux,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-préserver la biodiversité,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-préserver les fonds marins,false,true,false,false,false,false,false,true,false,"[""Eau"" ""Ecosystème""]","[""ressources"" ""biodiversite_solutions""]",fr
-préserver les sols,false,true,false,false,false,false,false,true,false,"[""Sols""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-red ensauvagement,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-reduire les emballages,false,true,false,false,false,false,false,true,false,"[""Economie des ressources"" ""Economie circulaire""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-respectueux de l'environnement,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration d'habitat,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-restauration de la biodiversité,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration de la nature,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration des coraux,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration des forêts,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration des habitats,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-restauration des milieux,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration des écosystèmes,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restauration du récif corallien,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restaurer la biodiversité,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restaurer la nature,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restaurer la qualité de l’air,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restaurer la qualité des sols,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-restaurer les habitats,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-ré ensauvagement,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-réintroduction d'espèce,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-réserve de biosphère,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-réserve naturelle,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-réserve sauvage,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-sauver des espèces,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-sciences participatives,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-sol vivant,false,true,false,false,false,false,false,true,false,"[""Ecosystème"" ""Sols""]","[""ressources"" ""biodiversite_solutions""]",fr
-solutions fondées sur la nature,false,true,false,false,false,false,false,true,false,"[""General""]","[""biodiversite_solutions""]",fr
-trame verte,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-trame verte et bleu,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-transformation des pratiques agricoles,false,true,false,false,false,false,false,true,false,"[""Sols""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-végétalisation des espaces urbains,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-végétalisation des villes,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-zone naturelle protégée,false,true,false,false,false,false,false,true,false,"[""Ecosystème"" ""Forêt""]","[""biodiversite_solutions"" ""ressources_solutions""]",fr
-zone sauvage,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-équilibre pour la faune et la flore,false,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions""]",fr
-éteindre l'éclairage public,false,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions""]",fr
-agriculteur bio,true,true,false,false,false,false,false,true,false,"[""Sols""]","[""biodiversite_solutions_indirectes"" ""ressources_solutions_indirectes""]",fr
-compostable,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-infrastructure résiliente,true,true,false,false,false,false,false,true,false,"[""Batiments""]","[""biodiversite_solutions_indirectes""]",fr
-manger bio,true,true,false,false,false,false,false,true,false,"[""Agriculture""]","[""biodiversite_solutions_indirectes""]",fr
-nettoyage des plages,true,true,false,false,false,false,false,true,false,"[""Eau"" ""Ecosystème""]","[""biodiversite_solutions_indirectes"" ""ressources_solutions""]",fr
-parc national,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-parc naturel,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-toit-jardin,true,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions_indirectes""]",fr
-trame blanche,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-trame bleu,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-trame brune,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-trame noire,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-variété rustique,true,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions_indirectes""]",fr
-végétation,true,true,false,false,false,false,false,true,false,"[""General"" ""Sols"" ""Forêt""]","[""biodiversite_solutions_indirectes"" ""ressources_indirectes""]",fr
-zan,true,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions_indirectes""]",fr
-zéro artificialisation nette,true,true,false,false,false,false,false,true,false,"[""Ecosystème""]","[""biodiversite_solutions_indirectes""]",fr
-éteindre la lumière,true,true,false,false,false,false,false,true,false,,"[""biodiversite_solutions_indirectes""]",fr
-co deux,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-co2,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-combustibles fossiles,false,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes""]",fr
-dyoxide de carbone,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-cop21,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-ferme-usine,false,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes""]",fr
-fuel lourd,false,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes""]",fr
-fumée industrielle,false,false,false,true,false,false,true,false,false,"[""Industrie""]","[""changement_climatique_causes""]",fr
-gaz à effet de serre,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-greenwashing,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-inaction climatique,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-insuffisance climatique,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-mauvaise nouvelle pour le climat,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-méthane,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-pollution industrielle,false,false,false,true,false,false,true,false,false,"[""Industrie""]","[""changement_climatique_causes""]",fr
-élevage intensif,false,false,false,true,false,false,true,false,false,"[""Eau"" ""Sols"" ""Agriculture""]","[""ressources"" ""changement_climatique_causes""]",fr
-émission de carbone,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-émissions anthropiques,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-émissions importées,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-émissions liées à la consommation,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-émissions territoriales,false,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes""]",fr
-énergies fossiles,false,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes""]",fr
-aliments transformés,true,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes_indirectes""]",fr
-automobile,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-autoroutes,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-aviation,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-avion,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-azote,true,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes_indirectes""]",fr
-carburant,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-charbon,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes"" ""ressources_indirectes""]",fr
-chauffage,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-chauffage au fuel,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-chauffage au gaz,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-climatisation,true,false,false,true,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_causes_indirectes""]",fr
-diesel,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-déperdition de chaleur,true,false,false,true,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_causes_indirectes""]",fr
-emissions mondiales,true,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes_indirectes""]",fr
-essence,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-fioul,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-forage pétrolier,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes"" ""ressources_indirectes""]",fr
-fuel,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-gaspillage alimentaire,true,false,false,true,false,false,true,false,false,"[""Economie des ressources""]","[""changement_climatique_causes_indirectes""]",fr
-gaz,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-gaz carbonique,true,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes_indirectes""]",fr
-gaz de schiste,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-gaz naturel,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes"" ""ressources_indirectes""]",fr
-industrialisation,true,false,false,true,false,false,true,false,false,"[""Industrie"" ""Concepts généraux""]","[""changement_climatique_causes_indirectes"" ""ressources_indirectes""]",fr
-industrie,true,false,false,true,false,false,true,false,false,"[""Industrie""]","[""changement_climatique_causes_indirectes""]",fr
-infrastructures routières,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-kérosène,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-lignite,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-logement mal isolé,true,false,false,true,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_causes_indirectes""]",fr
-malbouffe,true,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes""]",fr
-méga-camions,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-or noir,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes""]",fr
-passoire thermique,true,false,false,true,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_causes_indirectes""]",fr
-cop26,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-passoire énergétique,true,false,false,true,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_causes_indirectes""]",fr
-prendre l'avion,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-puit de pétrole,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes"" ""ressources_indirectes""]",fr
-pétrole,true,false,false,true,false,false,true,false,false,"[""Energie""]","[""changement_climatique_causes_indirectes"" ""ressources_indirectes""]",fr
-secteur tertiaire,true,false,false,true,false,false,true,false,false,"[""General""]","[""changement_climatique_causes_indirectes""]",fr
-serres chauffées,true,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes""]",fr
-super-poids lourds,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-suv,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-trafic routier,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-transport,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-transport aérien,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-transport routier,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-transporteur,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-usine,true,false,false,true,false,false,true,false,false,"[""Industrie""]","[""changement_climatique_causes_indirectes""]",fr
-vache,true,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes""]",fr
-viande,true,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes""]",fr
-voiture,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-voiture thermique,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-vol direct,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-vol paris new york,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-voyager,true,false,false,true,false,false,true,false,false,"[""Transport""]","[""changement_climatique_causes_indirectes""]",fr
-élevage,true,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes""]",fr
-élevage bovine,true,false,false,true,false,false,true,false,false,"[""Agriculture""]","[""changement_climatique_causes_indirectes""]",fr
-îlot de chaleur,true,false,false,true,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_causes_indirectes""]",fr
-aléas climatiques,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-année la plus chaude,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-arrêt des centrales nucléaires,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-augmentation des précipitations,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-augmentation des risques de sécheresse,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-blanchissement des coraux,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-canicule,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-canicule marine,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-catastophe écologique,false,false,false,false,false,false,true,false,false,"[""Concepts généraux""]","[""ressources"" ""changement_climatique_consequences""]",fr
-catastrophe climatique,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-chaleur extrême,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources_indirectes"" ""changement_climatique_consequences""]",fr
-chaleur record,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-chenille processionnaire,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-climatique extrême,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-conflit d’usage de l’eau,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-diminution de la banquise,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-diminution des glaciers,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-disparition des coraux,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-disparition des glaciers,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-disparition des récifs coralliens,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-décès à cause de la chaleur,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-déficit de pluie,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-déstabilisation atmosphérique,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_constat"" ""changement_climatique_consequences""]",fr
-effondrement de la falaise,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-fonte de la banquise,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-fonte des calottes glacières,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-fonte des glaces,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-fonte des glaciers,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-fonte du permafrost,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-glissement de terrain,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-hausse de la température du globe,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-hausse des températures,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-hausse du niveau de la mer,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-hausse du niveau des océans,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-hausse du niveau marin,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-inondations à répétition,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-intensification du cycle de l’eau,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-jour le plus chaud,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-l'hiver le plus chaud,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-l'hiver le plus sec,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-l'été le plus chaud,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-la planète se réchauffe,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-le climat du futur,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-les eaux se réchauffent,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-maladaptation,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-malle adaptation,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-manque d'eau,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-manquer d'eau,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-migrant climatique,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-migration climatique,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-montée des eaux,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-montée du niveau de la mer,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-montée du niveau des océans,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-mort liées à la canicule,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-mort liées à la chaleur,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-mort à cause de la canicule,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-mort à cause de la chaleur,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-morte à cause de la canicule,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-morte à cause de la chaleur,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-météorologique extrême,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-pénurie de neige,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-pollution aux particules fines,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-pollution à l’ozone,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-printemps le plus pluvieux,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-prolifération de moustiques,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-pénurie d'eau,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-rareté de la ressource en eau,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-rareté saisonnière de la ressource en eau,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-raréfaction de la ressource en eau,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-record de température,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-retrait gonflement des argiles,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-réfugié climatique,false,false,false,false,false,false,true,false,false,"[""General""]","[""changement_climatique_consequences""]",fr
-salinisation des sols,false,false,false,false,false,false,true,false,false,"[""Eau"" ""Sols""]","[""ressources"" ""changement_climatique_consequences""]",fr
-stress hydrique,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-température extrême,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-température record,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-températures plus hautes,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-trop grande chaleur,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-vague de chaleur,false,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences""]",fr
-élévation de la température,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-élévation des températures,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-élévation du niveau de la mer,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-élévation du niveau des océans,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-élévation du niveau marin,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-érosion côtière,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-érosion des côtes,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-érosion du littoral,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-été le plus chaud,false,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences""]",fr
-40 degrés,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-50 degrés,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-accès à l’eau,true,false,false,false,false,false,true,false,false,"[""Eau""]","[""ressources"" ""changement_climatique_consequences_indirectes""]",fr
-anomalie de températures,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-augmentation des températures,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-catastrophe,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-cerné par les eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-cinquante degrés,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-crue,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-crue centennale,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-emporté par les eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-englouti par les eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-forte chaleur,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-forte pluie,true,false,false,false,false,false,true,false,false,"[""Eau""]","[""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-gel printanier,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-il n'y a plus de saison,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-importante précipitation,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-inondable,true,false,false,false,false,false,true,false,false,"[""Batiments""]","[""changement_climatique_consequences_indirectes""]",fr
-inondation,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-l'eau est monté,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-l'eau qui est monté,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-la roya,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-les eaux sont montées,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-millimètre d'eau,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-mois le plus chaud,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-ouragan,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-piégé par les eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-pluie extrême,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-pluie intense,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-pluie torrentielle,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-plus chaud que la normale,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-plus chaude que la normale,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-plus de saisons,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-plus sec que la normale,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-pluviométrie importante,true,false,false,false,false,false,true,false,false,"[""Eau""]","[""changement_climatique_consequences_indirectes"" ""ressources_indirectes""]",fr
-pollution de l'air,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-période la plus chaude,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-quarante degrés,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-ruissellement de l'eau,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-ruissellement des eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-sous l'eau,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-sous les eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-submergé par les eaux,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-submersion,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-submersion marine,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-surchauffe,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-tempête xynthia,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-trop d'eau,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-très chaud,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-érosion,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-étouffer,true,false,false,false,false,false,true,false,false,,"[""changement_climatique_consequences_indirectes""]",fr
-accord de paris,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-anthropocène,false,false,false,false,false,true,true,false,false,"[""Concepts généraux""]","[""ressources"" ""changement_climatique_constat""]",fr
-bilan carbone,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-climatique,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-climatologue,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-climatoscepticisme,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-conditions de vie sur terre,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-conférence climat,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-conférence des nations unies sur le climat,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-conférence des nations unies sur les changements climatiques,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-conférence des parties,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-convention des nations unies sur le climat,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cop trente,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cop vingt-et-un,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cop vingt-huit,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cop vingt-neuf,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cop29,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cop30,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-crise planétaire,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-crédit carbone,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-cycle du carbone,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-défi climatique,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-effet de serre,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-empreinte carbone,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-expert du climat,false,false,false,false,false,true,true,false,false,"[""General""]","[""changement_climatique_constat""]",fr
-experte du climat,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-giec,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-habitabilité de la planète,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-haut conseil pour le climat,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-impact carbone,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-mix énergétique,false,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources"" ""changement_climatique_constat""]",fr
-méga-orage,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-neutralité carbone,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-neutralité climatique,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-pollution émise localement,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-revue nature climate change,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-réchauffement de l’atmosphère,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-réchauffement des océans,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-réchauffement des températures,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-réchauffement planétaire,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-scope un et deux,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-seuil de réchauffement,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-soutenabilité environnementale,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-transition agricole,false,false,false,false,false,true,true,false,false,"[""General""]","[""changement_climatique_constat""]",fr
-transition climatique,false,false,false,false,false,true,true,false,false,"[""General""]","[""changement_climatique_constat""]",fr
-transition en dehors des énergies fossiles,false,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources_solutions"" ""changement_climatique_constat""]",fr
-transition verte,false,false,false,false,false,true,true,false,false,"[""General""]","[""changement_climatique_constat""]",fr
-transition énergétique,false,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources"" ""changement_climatique_constat""]",fr
-un climat qui change,false,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat""]",fr
-émissions mondiales de co deux,false,false,false,false,false,true,true,false,false,"[""General""]","[""changement_climatique_constat""]",fr
-émissions mondiales de co2,false,false,false,false,false,true,true,false,false,"[""General""]","[""changement_climatique_constat""]",fr
-air frais,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-atmosphère,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-baisse des températures,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-banquise,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-batterie,true,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes""]",fr
-bouquet énergétique,true,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes""]",fr
-bâtiment,true,false,false,false,false,true,true,false,false,"[""Batiments""]","[""changement_climatique_constat_indirectes""]",fr
-climat,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-climatosceptique,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-consommation énergétique,true,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes""]",fr
-défi de notre siècle,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-eau de pluie,true,false,false,false,false,true,true,false,false,"[""Eau""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes""]",fr
-facture énergétique,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-fraîcheur,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-glacier,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-inégalité,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-jamais un tel phénomène,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-mix électrique,true,false,false,false,false,true,true,false,false,"[""Energie""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes""]",fr
-météo des forêts,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-ozone,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-performance énergétique,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-permafrost,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-pont thermique,true,false,false,false,false,true,true,false,false,"[""Batiments""]","[""changement_climatique_constat_indirectes""]",fr
-santé publique,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-sol,true,false,false,false,false,true,true,false,false,"[""Sols""]","[""ressources_indirectes"" ""changement_climatique_constat_indirectes""]",fr
-température,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-zone inondable,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-éco-anxiété,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-énergie,true,false,false,false,false,true,true,false,false,,"[""changement_climatique_constat_indirectes""]",fr
-acidification des oceans,false,false,false,false,false,false,false,false,true,"[""Eau"" ""Sols""]","[""ressources""]",fr
-acidification des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-appauvrissement des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-bois énergie,false,false,false,false,false,false,false,false,true,"[""Energie"" ""Forêt""]","[""ressources""]",fr
-cobalt,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-compactage des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-conflits d’usage de l’eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-crise climatique,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-crise écologique,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-cycle de l’eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-dessalement de l’eau de mer,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-dépassement des limites planétaires,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-eau de ruissellement,false,false,false,false,false,false,false,false,true,"[""Eau"" ""Sols""]","[""ressources""]",fr
-eaux de ruissellement,false,false,false,false,false,false,false,false,true,"[""Eau"" ""Sols""]","[""ressources""]",fr
-eaux souterraines,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-engrais chimique,false,false,false,false,false,false,false,false,true,"[""Air"" ""Eau"" ""Sols""]","[""ressources""]",fr
-eutrophisation,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-exploitation minière,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-exploration minière,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-fortes chaleurs,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-fumées industrielles,false,false,false,false,false,false,false,false,true,"[""air""]","[""ressources""]",fr
-gestion des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-gestion forestière,false,false,false,false,false,false,false,false,true,"[""Forêt""]","[""ressources""]",fr
-impact des emballages plastiques,false,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources""]",fr
-impact environnemental,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-industrie extractive,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-industrie minière,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-jour du dépassement,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-limites planétaires,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-manque d’eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-matière critique,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-matériaux polluants,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-mauvaise santé des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-minerais,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-minerais critiques,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-minerais stratégiques,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-modifier nos fonds marins,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-métal critique,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-métal rare,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-métaux critiques,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-métaux rares,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-nappe d'eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-politiques climatiques,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-pollution de l'eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-pollution des nappes,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-problème de sécurité alimentaire,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-pénurie d’eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-qualité de l'eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-qualité de l’eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-raréfaction de l’eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-rejet polluant,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-ressource en eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources"" ""ressources_indirectes""]",fr
-ressource minérale,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-ressource naturelle,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-ressource stratégique,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-ressources planétaires,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-réserve d'eau,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-salinisation des nappes,false,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources""]",fr
-santé des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-sevrage aux énergies fossiles,false,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources""]",fr
-sol appauvri,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-sol dégradé,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-sols pollués,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-surexploitation,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-surexploitation des ressources,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-surpâturage,false,false,false,false,false,false,false,false,true,"[""Air"" ""Eau"" ""Sols""]","[""ressources""]",fr
-tassement des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-terre rare,false,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources""]",fr
-transformation écologique,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-trier ses déchets,false,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources""]",fr
-épuisement des ressources,false,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources""]",fr
-érosion des sols,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-érosion hydrique,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-érosion éolienne,false,false,false,false,false,false,false,false,true,"[""Sols""]","[""ressources""]",fr
-abondance,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-acidification,true,false,false,false,false,false,false,false,true,"[""Eau"" ""Sols""]","[""ressources_indirectes""]",fr
-besoin énergétique,true,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_indirectes""]",fr
-compagnie gazière,true,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_indirectes""]",fr
-compagnie pétrolière,true,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_indirectes""]",fr
-cuivre,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-décharges,true,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_indirectes""]",fr
-déchets toxiques,true,false,false,false,false,false,false,false,true,"[""Air"" ""Eau"" ""Sols"" ""Forêt""]","[""ressources_indirectes""]",fr
-déchèterie,true,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_indirectes""]",fr
-eau absorbée,true,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_indirectes""]",fr
-eau potable,true,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_indirectes""]",fr
-eaux douces,true,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_indirectes""]",fr
-extraction,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-forestier,true,false,false,false,false,false,false,false,true,"[""Forêt""]","[""ressources_indirectes""]",fr
-forestière,true,false,false,false,false,false,false,false,true,"[""Forêt""]","[""ressources_indirectes""]",fr
-fuite d'eau,true,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_indirectes""]",fr
-gaspillage,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-gigantisme,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-gisement,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-gâchis,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-gâchis alimentaire,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-incendie,true,false,false,false,false,false,false,false,true,"[""Forêt""]","[""ressources_indirectes""]",fr
-industrie pétrolière,true,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_indirectes""]",fr
-insécurité alimentaire,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-invendus,true,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_indirectes""]",fr
-jeter,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-lithium,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-manganèse,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-matière première,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-mauvaise gestion,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-mines,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-nature empoisonée,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-nickel,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-produit chimique,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-produit toxique,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-pénurie,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-ressource énergétique,true,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_indirectes""]",fr
-restes alimentaires,true,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_indirectes""]",fr
-restes de cantine,true,false,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_indirectes""]",fr
-ruisselement,true,false,false,false,false,false,false,false,true,"[""Eau"" ""Sols""]","[""ressources_indirectes""]",fr
-silicium,true,false,false,false,false,false,false,false,true,"[""Métaux et minerais""]","[""ressources_indirectes""]",fr
-substance chimique,true,false,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_indirectes""]",fr
-suffoquer,true,false,false,false,false,false,false,false,true,"[""Sols"" ""Forêt""]","[""ressources_indirectes""]",fr
-uranium,true,false,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_indirectes""]",fr
-éco-sac wc,true,false,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_indirectes""]",fr
-bio,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-compost,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-composter,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-compostés,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-consigne,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-consommer autrement,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-durée de vie,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-manger mieux,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-mousseur,true,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions_indirectes""]",fr
-méga bassine,true,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions_indirectes""]",fr
-plantation,true,true,false,false,false,false,false,false,true,"[""Forêt""]","[""ressources_solutions_indirectes""]",fr
-plus d'oxygène,true,true,false,false,false,false,false,false,true,"[""Air""]","[""ressources_solutions_indirectes""]",fr
-pratique vertueuse,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-produits en vrac,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-produits locaux,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-rationnement,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-rationner,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-recyclable,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-recycle,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-réparation,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-se nourrir mieux,true,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions_indirectes""]",fr
-toilette sèche,true,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions_indirectes""]",fr
-toilette à double débit,true,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions_indirectes""]",fr
-tri,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-trier,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-vrac,true,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions_indirectes""]",fr
-économie d'énergie,true,true,false,false,false,false,false,false,true,"[""Energie""]","[""ressources_solutions_indirectes""]",fr
-acv,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-analyse de cycle de vie,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-anti gaspi,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-baisse de consommation d'eau,false,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions""]",fr
-bio inspiration,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-biodéchets,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-bioinspiration,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-biomimétisme,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-circuits courts,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-déchet valorisé,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-fin de l'abondance,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-gaspiller moins,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-indice de réparabilité,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-jeter moins,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-lutte contre le gaspillage,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-maîtrise de la demande,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-moins consommer,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-moins gaspiller,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-moins jeter,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-partage des ressources,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-poubelle jaune,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-préservation des sols,false,true,false,false,false,false,false,false,true,"[""Sols""]","[""ressources_solutions""]",fr
-préserver l'eau,false,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions""]",fr
-recyclerie,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-repair cafés,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-ressource renouvelable,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-récupérateur d’eau,false,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions""]",fr
-réduction des déchets,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-réduire la production de plastique,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-réparabilité,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-réutilisation des eaux,false,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions""]",fr
-réutilisation des ressources,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-stockage d’eau,false,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions""]",fr
-stocker l'eau,false,true,false,false,false,false,false,false,true,"[""Eau""]","[""ressources_solutions""]",fr
-système alimentaire équitable,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-sécurité environnementale,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-tri des ordures,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-tri sélectif,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-un environnement alimentaire sain,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-zéro déchet,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-zéro emballage,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-écologie industrielle,false,true,false,false,false,false,false,false,true,"[""Concepts généraux""]","[""ressources_solutions""]",fr
-économie du réemploi,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
-éviter le plastique,false,true,false,false,false,false,false,false,true,"[""Economie circulaire""]","[""ressources_solutions""]",fr
+adaptation au changement climatique,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+adaptation au dérèglement climatique,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+adaptation au réchauffement climatique,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+adaptation climatique,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+agro écologie,false,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+agro écologique,false,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+agroforesterie,false,true,false,false,false,false,true,true,true,"{Forêt,Agriculture}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+agroécologie,false,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+amélioration des pratiques d’élevage,false,true,false,false,false,false,true,false,true,"{Eau,Agriculture,Forêt,Air,Sols}","{ressources_solutions,adaptation_climatique_solutions}",fr
+améliorer les systèmes d'alerte et d'évacuation,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+aquaculture durable,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture}","{ressources_solutions,attenuation_climatique_solutions,biodiversite_solutions_indirectes,adaptation_climatique_solutions}",fr
+arbre planté,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+bienfaits de la nature,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+bon pour la planète,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+changer nos habitudes alimentaires,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+désalinisation des eaux,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+développement de la planète,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+eaux usées traitées,false,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions},fr
+eco-prêt à taux zéro,false,true,false,false,false,false,true,false,false,{Batiments},"{attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+foresterie urbaine,false,true,false,false,false,false,true,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+forêt urbaine,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+gestion de la ressource en eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+gestion du littoral,false,true,false,false,false,false,true,false,false,{Ecosystème},{adaptation_climatique_solutions},fr
+gestion durable des forêts,false,true,false,false,false,false,true,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+gestion durable des terres cultivables,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{ressources_solutions,attenuation_climatique_solutions,biodiversite_solutions_indirectes,adaptation_climatique_solutions}",fr
+limiter l’érosion des côtes,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+lutte contre le gaspillage d’eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+lutter contre l’érosion,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+mesure environnementale,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_solutions,ressources,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+nous adapter à un futur incertain,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{ressources_solutions,adaptation_climatique_solutions}",fr
+plantant des arbres,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+plantation d'arbres,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+plante des arbres,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+plantent des arbres,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+planter des arbres,false,true,false,false,false,false,true,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+planté des arbres,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+prise de conscience environnementale,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+prise de conscience écologique,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+préservation de la nature,false,true,false,false,false,false,true,true,true,"{Ecosystème,""Concepts généraux""}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+préservation de la ressource en eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+préservation des forêts,false,true,false,false,false,false,true,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+préserver la forêt,false,true,false,false,false,false,true,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+préserver la nature,false,true,false,false,false,false,true,true,true,"{Ecosystème,""Concepts généraux""}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+préserver les forêts,false,true,false,false,false,false,true,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+prévention des catastrophes naturelles,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+prévention des inondations,false,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions},fr
+pêche durable,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture}","{ressources_solutions,attenuation_climatique_solutions,biodiversite_solutions_indirectes,adaptation_climatique_solutions}",fr
+reforestation,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+zéro carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+renaturer,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+renforcer les digues,false,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions},fr
+renforcer les dunes,false,true,false,false,false,false,true,false,false,{Ecosystème},{adaptation_climatique_solutions},fr
+restriction d’eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+retenue collinaire,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+revégétalisation,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+revégétaliser,false,true,false,false,false,false,true,true,true,"{Ecosystème,Sols}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+récupérateur d'eau,false,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions},fr
+récupérer l'eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+réduction de la demande en eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+réduire l’élevage intensif,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{ressources_solutions,biodiversite_solutions_indirectes,adaptation_climatique_solutions}",fr
+rénovation des batiments,false,true,false,false,false,false,true,false,false,{Batiments},"{attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+rénovation thermique,false,true,false,false,false,false,true,false,false,{Batiments},"{attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+réserve d’eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+résistant à la sécheresse,false,true,false,false,false,false,true,true,false,"{Ecosystème,General}","{biodiversite_solutions,adaptation_climatique_solutions}",fr
+résistante à la sécheresse,false,true,false,false,false,false,true,true,false,"{Ecosystème,General}","{biodiversite_solutions,adaptation_climatique_solutions}",fr
+réutilisation des eaux usées traitées,false,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions},fr
+sauvegarde de la ressource en eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+tva verte,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+tévéa verte,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+verdir la politique agricole,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",Agriculture}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+vertueux pour la planète,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_solutions,ressources_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+végétalisation,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+végétaliser,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+végétalisé,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+végétalisée,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions,adaptation_climatique_solutions}",fr
+économie d’eau,false,true,false,false,false,false,true,false,true,{Eau},"{ressources_solutions,adaptation_climatique_solutions}",fr
+économiser l'eau,false,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions},fr
+îlot de fraîcheur,false,true,false,false,false,false,true,false,false,{Ecosystème},{adaptation_climatique_solutions},fr
+aménagement du territoire,true,true,false,true,true,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_concepts_generaux_indirectes,adaptation_climatique_solutions_indirectes,ressources_indirectes,changement_climatique_causes_indirectes}",fr
+barrage,true,true,false,true,false,false,true,true,true,"{Eau,Energie,""Destruction des habitats""}","{ressources_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+bon pour la santé,true,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+changer leurs habitudes,true,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_indirectes}",fr
+changer nos comportements,true,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+changer nos habitudes,true,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_indirectes}",fr
+digue,true,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions_indirectes},fr
+dune,true,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions_indirectes},fr
+espace vert,true,true,false,false,false,false,true,true,true,"{Ecosystème,Sols}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+faire baisser la température,true,true,false,false,false,false,true,false,false,,"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes}",fr
+forêt,true,true,false,false,true,false,true,true,true,"{Ecosystème,Forêt}","{attenuation_climatique_solutions_indirectes,biodiversite_concepts_generaux_indirectes,adaptation_climatique_solutions_indirectes,ressources_indirectes}",fr
+gestion de l'eau,true,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions_indirectes},fr
+gestion des milieux aquatiques,true,true,false,false,false,false,true,true,false,"{Ecosystème,Eau}","{adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+jachère,true,true,false,false,false,false,true,true,true,"{Agriculture,Sols}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+jardin,true,true,false,false,false,false,true,true,false,{Ecosystème},"{adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+manipuler la terre,true,true,false,false,false,false,true,false,false,{Agriculture},"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes}",fr
+mega bassine,true,true,false,false,false,false,true,false,false,{Eau},{adaptation_climatique_solutions_indirectes},fr
+miscanthus,true,true,false,false,false,false,true,false,false,{Agriculture},{adaptation_climatique_solutions_indirectes},fr
+norme,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_indirectes,biodiversite_solutions_indirectes}",fr
+ombre,true,true,false,false,false,false,true,false,false,{Ecosystème},{adaptation_climatique_solutions_indirectes},fr
+parc,true,true,false,false,false,false,true,true,false,{Ecosystème},"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+pollution de l’eau,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+poumon vert,true,true,false,false,true,false,true,true,false,{Ecosystème},"{attenuation_climatique_solutions_indirectes,biodiversite_concepts_generaux_indirectes,adaptation_climatique_solutions_indirectes}",fr
+pratiques vertueuses,true,true,false,false,false,false,true,true,false,{Agriculture},"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+sorgho,true,true,false,false,false,false,true,false,false,{Agriculture},{adaptation_climatique_solutions_indirectes},fr
+système d'alerte,true,true,false,false,false,false,true,false,false,{General},{adaptation_climatique_solutions_indirectes},fr
+verdir,true,true,false,false,false,false,true,true,false,,"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+verdure,true,true,false,false,false,false,true,true,false,,"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+vertueux,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+ville durable,true,true,false,false,false,false,true,true,false,{General},"{attenuation_climatique_solutions_indirectes,adaptation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+absorption du carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+agir pour le climat,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+agriculture bio,false,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+agriculture biologique,false,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+agriculture de conservation,false,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+agriculture plus verte,false,true,false,false,false,false,true,true,true,"{Forêt,Air,Agriculture,Sols}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+ajustement carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+amélioration des pratiques d'élevage,false,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions},fr
+anti gaspillage,false,true,false,false,false,false,true,false,false,"{""Economie des ressources""}",{attenuation_climatique_solutions},fr
+antigaspi,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",""Economie des ressources""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+antigaspillage,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",""Economie des ressources""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+arrêter de prendre l'avion,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+atténuation du changement climatique,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+avihonte,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+avion vert,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+avion à hydrogène,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+baisse des émissions de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+baisse des émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+baisse du trafic aérien,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+bas carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+biocarburant,false,true,false,false,false,false,true,false,true,"{Transport,Energie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+biochar,true,true,false,false,false,false,true,true,false,{Agriculture},"{biodiversite_solutions_indirectes,attenuation_climatique_solutions}",fr
+bioclimatique,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+biogaz,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+biomasse,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+bois-énergie,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+bonus climatique,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+bonus écologique,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+bonus-malus écologique,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+borne de recharge,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+bâtiment à énergie positive,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+béton bas carbone,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+captage et stockage,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+capteur de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+capture et séquestration de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+capturer le carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+carburant d'aviation durable,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+carburant d'origine non fossile,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+carburant de synthèse,false,true,false,false,false,false,true,false,true,"{Transport,Energie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+carburant durable,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+centrale hydroélectrique,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+changer de modèle agricole,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",Agriculture}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+changer de modèle économique,false,true,false,false,false,false,true,false,true,"{""Economie circulaire"",General}","{ressources_solutions,attenuation_climatique_solutions}",fr
+ciment de nouvelle génération,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+ciment durable,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+consommation plus responsable,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",""Economie des ressources""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+consommation responsable,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",""Economie des ressources""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+contre les émissions de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+crit'air,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+descente énergétique,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+diagnostic de performance energétique,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+diminuer les émissions de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+posidonie,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+diminuer les émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+droit environnemental,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+décarbonation,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+décarboner,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+décarboné,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+décarbonée,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+déchet de canne à sucre,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+décroissance énergétique,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+dépolluer,false,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions},fr
+dépollution,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+eco-prêt à taux 0,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+ecomobilité,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+efficacité énergétique,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",Energie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+en consommant moins,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+exploitation raisonnée,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+fin de la vente des voitures thermiques,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+fiscalité environnementale,false,true,false,false,false,false,true,true,false,{Industrie},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+flygskam,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+forêt mosaïque,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+geste écologique,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+géothermie,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+honte de prendre l'avion,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+huile de friture usagé,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+hydrogène,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+hydrogène vert,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+hydroélectricité,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+isf climatique,false,true,false,false,false,false,true,false,false,{Industrie},{attenuation_climatique_solutions},fr
+isolation par l'extérieur,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+isolation thermique,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+journée de la biodiversité,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+journée de la terre,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+journée mondiale de la vie sauvage,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+leasing électrique,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+limiter la hausse des températures,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+limiter les émissions de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+lutte contre le gaspillage alimentaire,false,true,false,false,false,false,true,false,false,"{""Economie des ressources""}",{attenuation_climatique_solutions},fr
+lutte contre le gaspillage énergétique,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+ma prime rénov,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+maison autonome,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+maison passive,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+malus écologique,false,true,false,false,false,false,true,false,true,"{Transport,""Concepts généraux""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+maprimerénov,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+matériaux biosourcés,false,true,false,false,false,false,true,false,true,"{""Economie circulaire"",Batiments}","{ressources_solutions,attenuation_climatique_solutions}",fr
+matériaux plus vertueux,false,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions},fr
+matériaux recyclables,false,true,false,false,false,false,true,false,true,"{""Economie circulaire"",Batiments}","{ressources_solutions,attenuation_climatique_solutions}",fr
+matériaux recyclés,false,true,false,false,false,false,true,false,true,"{""Economie circulaire"",Batiments}","{ressources_solutions,attenuation_climatique_solutions}",fr
+mobilité douce,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+mobilité durable,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+moins polluant,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+moins polluer,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+moins prendre l'avion,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+méthanisation,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+méthaniseur,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+net zéro émission,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+objectif climatique,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+panneau solaire,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+panneaux solaires,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+parc photovoltaïque,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+parc éolien,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+photovoltaïque,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+plastique recyclé,false,true,false,false,false,false,true,true,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+pollueur payeur,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+prime à la casse,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+produits verts,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources,biodiversite_solutions,attenuation_climatique_solutions}",fr
+protection de la planète,false,true,false,false,false,false,true,false,false,{Ecosystème},{attenuation_climatique_solutions},fr
+protection des cours d’eau,false,true,false,false,false,false,true,true,true,{Eau},"{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+protection des océans,false,true,false,false,false,false,true,false,false,{Eau},{attenuation_climatique_solutions},fr
+protection des tourbières,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+protection du vivant,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+puits carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+puits de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+quota de pêche,false,true,false,false,false,false,true,false,true,"{Eau,Agriculture}","{ressources_solutions,attenuation_climatique_solutions}",fr
+recyclage,false,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+recyclant,false,true,false,false,false,false,true,true,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+recycler,false,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+remplacer les énergies fossiles,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+respect de l’environnement,false,true,false,false,false,false,true,false,true,"{Ecosystème,""Concepts généraux""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+respectueux de l’environnement,false,true,false,false,false,false,true,true,true,"{Ecosystème,""Concepts généraux""}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+restauration des tourbières,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+restauration des zones humides,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+restauration écologique,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+restaurer les tourbières,false,true,false,false,false,false,true,true,false,{Ecosystème},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+réduction de la consommation,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions_indirectes,attenuation_climatique_solutions}",fr
+réduction des gaspillages énergétiques,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+réduction des émissions de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+réduction des émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+réduction du cheptel,false,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions},fr
+réduction du gaspillage alimentaire,false,true,false,false,false,false,true,false,true,"{Eau,Forêt,""Economie des ressources"",Air,Sols}","{ressources_solutions,attenuation_climatique_solutions}",fr
+réduction du gaspillage énergétique,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+réduire la consommation,true,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions_indirectes,attenuation_climatique_solutions}",fr
+réduire la consommation d’eau,false,true,false,false,false,false,true,true,true,{Eau},"{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+réduire le cheptel,false,true,false,false,false,false,true,true,true,"{Air,Eau,Agriculture,Sols}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+réduire le trafic aérien,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+réduire les émissions de carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+réduire les émissions de gaz à effet de serre,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+réduire les émissions d’azote,false,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions},fr
+réduire sa consommation de viande,false,true,false,false,false,false,true,false,true,"{""Concepts généraux"",Agriculture}","{ressources_solutions,attenuation_climatique_solutions}",fr
+réemploi,false,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+réseau de chaleur,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+réseaux de chaleur,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+réservoir d'hydrogène,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+sans émettre de co deux,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+sans émettre de co2,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+se débarrasser des énergies fossiles,false,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions},fr
+se décarboner,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+semaine du développement durable,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+sevrage des énergies fossiles,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+sobriété,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+sobriété énergétique,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+société écologique,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+sortie des énergies fossiles,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+sortie du charbon,false,true,false,false,false,false,true,false,true,"{Air,""Métaux et minerais"",Energie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+stockage du carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+stockage du carbone dans les sols,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+stockage du co deux,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+stocker le carbone,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+séquestration du carbone,false,true,false,false,true,false,true,true,false,{Industrie},"{biodiversite_concepts_generaux,attenuation_climatique_solutions}",fr
+technologie verte,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+transport décarboné,false,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions},fr
+valorisation des déchets,false,true,false,false,false,false,true,false,true,"{""Economie des ressources"",Energie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+ville écologique,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+zfe,false,true,false,false,false,false,true,false,true,"{Transport,Air}","{ressources_solutions,attenuation_climatique_solutions}",fr
+zone à faible émission,false,true,false,false,false,false,true,false,true,"{Transport,Air}","{ressources_solutions,attenuation_climatique_solutions}",fr
+zéro plastique,false,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+zéro émission nette,false,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions},fr
+éco conception,false,true,false,false,false,false,true,false,true,"{""Economie circulaire"",Industrie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+éco geste,false,true,false,false,false,false,true,true,false,{General},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+éco organisme,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+éco responsable,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+écoconception,false,true,false,false,false,false,true,false,true,"{""Economie circulaire"",Industrie}","{ressources_solutions,attenuation_climatique_solutions}",fr
+économie circulaire,false,true,false,false,false,false,true,true,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+économie d’énergie,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+économie qui répare,false,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{ressources_solutions,attenuation_climatique_solutions}",fr
+économiser de l’énergie,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+écoresponsable,false,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{ressources_solutions,biodiversite_solutions,attenuation_climatique_solutions}",fr
+énergie durable,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+énergie renouvelable,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+énergie solaire,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+énergie verte,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+éolien,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+éolienne,false,true,false,false,false,false,true,false,true,{Energie},"{ressources_solutions,attenuation_climatique_solutions}",fr
+étiquetage unique des aliments,false,true,false,false,false,false,true,true,false,{Agriculture},"{biodiversite_solutions,attenuation_climatique_solutions}",fr
+activisme climatique,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+activiste pour le climat,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+agriculture durable,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+alternative,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_indirectes,biodiversite_solutions_indirectes}",fr
+alternative durable,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+approche systémique,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+atténuation,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+bardage en bois,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+biodégradable,true,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+bois d’oeuvre,true,true,false,false,false,false,true,false,true,"{Forêt,Batiments}","{attenuation_climatique_solutions_indirectes,ressources}",fr
+bonus automobile,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+borne électrique,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+bus,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+bus électrique,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+camion xxl,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+camion électrique,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+centrale nucléaire,true,true,false,false,false,false,true,false,false,{Energie},{attenuation_climatique_solutions_indirectes},fr
+changement de chaudière,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+compostage,true,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+covoiturage,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+déconstruire,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+décroissance,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+désobéissance civile,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+développement durable,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+epr,true,true,false,false,false,false,true,false,true,{Energie},"{attenuation_climatique_solutions_indirectes,ressources_solutions}",fr
+falloir ralentir,true,true,false,false,false,false,true,false,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+fret ferroviaire,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+habitude durable,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",""Economie des ressources""}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+industrie verte,true,true,false,false,false,false,true,false,true,"{""Concepts généraux"",Industrie}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+intercités,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+isolation,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+isoler la façade,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+isoler les fenêtres,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+label ab,true,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions_indirectes},fr
+label bio,true,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions_indirectes},fr
+label hve,true,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions_indirectes},fr
+label éco,true,true,false,false,false,false,true,false,false,{Industrie},{attenuation_climatique_solutions_indirectes},fr
+label écologique,true,true,false,false,false,false,true,false,false,{Industrie},{attenuation_climatique_solutions_indirectes},fr
+leasing social,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+ligne tgv,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+made in france,true,true,false,false,false,false,true,false,false,{Industrie},{attenuation_climatique_solutions_indirectes},fr
+manifestation pour le climat,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+marche du siècle,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+marche pour le climat,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+marche à pied,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+matériau isolant,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+matériaux isolants,true,true,false,false,false,false,true,false,false,,{attenuation_climatique_solutions_indirectes},fr
+militant écologiste,true,true,false,false,false,false,true,true,false,{General},"{attenuation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+militante écologiste,true,true,false,false,false,false,true,true,false,{General},"{attenuation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+moins de viande,true,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions_indirectes},fr
+nucléaire,true,true,false,false,false,false,true,false,true,{Energie},"{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+pass rail,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+passer à l'électrique,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+permaculture,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions,biodiversite_solutions_indirectes}",fr
+plus durable,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+plus d’oxygène,true,true,false,false,false,false,true,true,false,,"{attenuation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+poid lourd électrique,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+polyculture élevage,true,true,false,false,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+pompe à chaleur,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+prairie,true,true,false,false,false,false,true,true,false,{Ecosystème},"{attenuation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+principe de précaution,true,true,false,false,false,false,true,true,false,{General},"{attenuation_climatique_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+produire en europe,true,true,false,false,false,false,true,false,false,{Industrie},{attenuation_climatique_solutions_indirectes},fr
+préserver,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+recharge,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+relocaliser la production,true,true,false,false,false,false,true,false,false,{Industrie},{attenuation_climatique_solutions_indirectes},fr
+replantation,true,true,false,false,false,false,true,true,true,"{Eau,Forêt,Ecosystème,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+replanter,true,true,false,false,false,false,true,true,true,"{Eau,Forêt,Ecosystème,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+responsable,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+restreindre,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+restriction,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",General}","{attenuation_climatique_solutions_indirectes,ressources_indirectes,ressources_solutions_indirectes,biodiversite_consequences_indirectes,changement_climatique_consequences_indirectes,biodiversite_solutions_indirectes}",fr
+réacteur nucléaire,true,true,false,false,false,false,true,false,true,{Energie},"{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+réguler les températures,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+rénovation,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+rénovation énergétique,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+résistance thermique,true,true,false,false,false,false,true,false,false,{Batiments},{attenuation_climatique_solutions_indirectes},fr
+saf,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+se déplacer en vélo,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+taxe carbone,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+ter,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+tgv,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+train,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+trains régionaux,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+tramway,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+transport collectif,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+transport en commun,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+transport ferroviaire,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+transport fluvial,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+transport maritime,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+tri à la source,true,true,false,false,false,false,true,false,true,"{""Economie des ressources"",""Economie circulaire""}","{attenuation_climatique_solutions_indirectes,ressources_solutions}",fr
+té heu air,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+tégévé,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+voitures électriques,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+végan,true,true,false,false,false,false,true,false,true,"{Eau,Agriculture,Forêt,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+végane,true,true,false,false,false,false,true,false,false,{Agriculture},{attenuation_climatique_solutions_indirectes},fr
+végétarien,true,true,false,false,false,false,true,false,true,"{Eau,Agriculture,Forêt,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+végétarienne,true,true,false,false,false,false,true,false,true,"{Eau,Agriculture,Forêt,Air,Sols}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+véhicule électrique,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+vélo,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+zad,true,true,false,false,false,false,true,false,false,{Ecosystème},{attenuation_climatique_solutions_indirectes},fr
+zadisme,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+zadiste,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+économie de carburant,true,true,false,false,false,false,true,false,true,"{Transport,Energie}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes}",fr
+écotaxe,true,true,false,false,false,false,true,false,false,{Transport},{attenuation_climatique_solutions_indirectes},fr
+éducation au changement climatique,true,true,false,false,false,false,true,false,false,{General},{attenuation_climatique_solutions_indirectes},fr
+épargne citoyenne,true,true,false,false,false,false,true,true,true,"{""Concepts généraux"",""Economie des ressources""}","{attenuation_climatique_solutions_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+a69,false,false,false,true,false,false,true,true,false,"{Transport,""Destruction des habitats""}","{biodiversite_causes,changement_climatique_causes}",fr
+agribusiness,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+agriculture conventionnelle,false,false,false,true,false,false,true,true,true,"{Eau,Agriculture,Air,General,Sols}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+agriculture extensive,false,false,false,true,false,false,true,true,true,"{Sols,Agriculture,General}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+agriculture industrielle,false,false,false,true,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,General,Sols}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+agriculture intensive,false,false,false,true,false,false,true,true,true,"{Eau,Agriculture,Forêt,Air,General,Sols}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+artificialisation des milieux naturels,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+artificialisation des sols,false,false,false,true,false,false,false,true,true,"{Eau,""Destruction des habitats"",Sols}","{biodiversite_causes,ressources}",fr
+assèchement des zones humides,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+braconnage,false,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes},fr
+braconnier,false,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes},fr
+bétonisation,false,false,false,true,false,false,false,true,true,"{Eau,""Destruction des habitats"",Sols}","{biodiversite_causes,ressources}",fr
+bétonner les sols,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+cadmium,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{biodiversite_causes,ressources_indirectes}",fr
+changement d’usage des terres,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+chlordécone,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+coupe rase,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+destruction de la planète,false,false,false,true,false,false,true,true,true,"{Ecosystème,""Concepts généraux"",General}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+destruction des habitats naturels,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+destruction des milieux naturels,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+disparition des haies,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+décharge sauvage,false,false,false,true,false,false,false,true,true,"{Pollution,""Economie circulaire""}","{biodiversite_causes,ressources}",fr
+déchet toxique,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+déforestation,false,false,false,true,false,false,true,true,true,"{Ecosystème,Forêt,General}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+dépôt sauvage,false,false,false,true,false,false,false,true,true,"{Pollution,""Economie circulaire""}","{biodiversite_causes,ressources}",fr
+engrais azoté,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{biodiversite_causes,ressources}",fr
+engrais de synthèse,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{biodiversite_causes,ressources}",fr
+engrais phosphaté,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+extractivisme,false,false,false,true,false,false,false,true,true,"{""Concepts généraux"",""Surexploitation des ressources""}","{biodiversite_causes,ressources}",fr
+extractiviste,false,false,false,true,false,false,false,true,true,"{""Concepts généraux"",""Surexploitation des ressources""}","{biodiversite_causes,ressources}",fr
+glyphosate,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+herbicide,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+imperméabilisation des sols,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+intrant chimique,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{biodiversite_causes,ressources}",fr
+marée noire,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+massacre des terres,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+mauvaise nouvelle pour la planète,false,false,false,true,false,false,true,true,false,{General},"{biodiversite_causes,changement_climatique_causes}",fr
+micro-plastique,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+microplastique,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+micropolluant,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+multinationale agroalimentaire,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+métaux lourds,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{biodiversite_causes,ressources_indirectes}",fr
+nocif pour l'environnement,false,true,false,true,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_causes,ressources_solutions,changement_climatique_causes}",fr
+néonicotinoïde,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+paille en plastique,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+pas très écolo,false,false,false,true,false,false,true,true,false,{General},"{biodiversite_causes,changement_climatique_causes}",fr
+perméabilisation des sols,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+perte d’habitats,false,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes},fr
+pesticide,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{biodiversite_causes,ressources}",fr
+pesticide résiduel,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+pfas,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{biodiversite_causes,ressources}",fr
+pfoa,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{biodiversite_causes,ressources}",fr
+pfos,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{biodiversite_causes,ressources}",fr
+polluant,false,false,false,true,false,false,true,true,true,"{Pollution,""Concepts généraux"",General}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+pollueur,false,false,false,true,false,false,true,true,false,"{Pollution,General}","{biodiversite_causes,changement_climatique_causes}",fr
+pollution atmosphérique,false,false,false,true,false,false,true,true,false,{Pollution},"{biodiversite_causes,changement_climatique_consequences}",fr
+pollution chimique,false,false,false,true,false,false,false,true,true,"{Pollution,""Concepts généraux""}","{biodiversite_causes,ressources}",fr
+pollution de la mer,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+pollution des sols,false,false,false,true,false,false,false,true,true,"{Pollution,Sols}","{biodiversite_causes,ressources}",fr
+pollution environnementale,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+pollution plastique,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+pollution record,false,false,false,true,false,false,true,true,true,"{Eau,Pollution,Air,General,Sols}","{biodiversite_causes,ressources,changement_climatique_causes}",fr
+pression sur les milieux naturels,false,false,false,true,false,false,false,true,false,{General},{biodiversite_causes},fr
+productivisme,true,false,false,true,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_causes,ressources_indirectes,changement_climatique_causes}",fr
+productiviste,true,false,false,true,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_causes,ressources_indirectes,changement_climatique_causes}",fr
+produit phytosanitaire,false,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes},fr
+ptfe,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{biodiversite_causes,ressources}",fr
+pêche industrielle,false,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes},fr
+surpêche,false,false,false,true,false,false,false,true,true,"{Eau,""Surexploitation des ressources""}","{biodiversite_causes,ressources}",fr
+écocide,false,false,false,true,false,false,true,true,true,"{""Concepts généraux"",General}","{biodiversite_causes,changement_climatique_consequences,ressources}",fr
+épandage,false,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{biodiversite_causes,ressources}",fr
+étalement urbain,false,false,false,true,false,false,false,true,true,"{""Destruction des habitats"",Sols}","{biodiversite_causes,ressources}",fr
+acide,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+activité industrielle,true,false,false,true,false,false,true,true,true,"{Eau,Forêt,Air,General,Industrie,Sols}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+agro-industrie,true,false,false,true,false,false,true,true,false,"{Agriculture,General}","{changement_climatique_causes_indirectes,biodiversite_causes_indirectes}",fr
+agro-industriel,true,false,false,true,false,false,true,true,true,"{""Concepts généraux"",Agriculture,General}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+arsenic,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+bouteille en plastique,true,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes_indirectes},fr
+bétonner,true,false,false,true,false,false,false,true,true,"{""Destruction des habitats"",Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+cancérigène,true,false,false,true,false,false,false,true,true,"{Pollution,""Concepts généraux""}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+cancérogène,true,false,false,true,false,false,false,true,true,"{Pollution,""Concepts généraux""}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+capitalisme,true,false,false,true,false,false,true,true,true,"{""Concepts généraux"",""Economie des ressources"",General}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+commerce illégal d’espèces,true,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes_indirectes},fr
+complexe agro-industriel,true,false,false,true,false,false,false,true,false,{General},{biodiversite_causes_indirectes},fr
+déchet,true,false,false,true,false,false,true,true,true,"{Pollution,""Economie des ressources"",""Economie circulaire""}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+emballage,true,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes_indirectes},fr
+emballage en plastique,true,false,false,true,false,false,true,true,true,"{Pollution,""Economie des ressources"",""Economie circulaire""}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+emballage plastique,true,false,false,true,false,false,true,true,true,"{Pollution,""Economie des ressources"",""Economie circulaire""}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+feux,true,false,false,true,false,false,true,true,false,"{""Destruction des habitats""}","{changement_climatique_consequences_indirectes,biodiversite_causes_indirectes}",fr
+feux de forêt,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+fluor,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+fongicide,true,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes_indirectes},fr
+forêt brûle,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêt d'algues,true,false,false,true,false,false,true,true,true,"{Forêt,""Espèces exotiques envahissantes""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêt détruit,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêt détruite,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêt ravagé,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêt ravagée,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêts brûlent,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+forêts ont été détruites,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+huile de palme,true,false,false,true,false,false,false,true,false,{General},{biodiversite_causes_indirectes},fr
+incendie de forêt,true,false,false,true,false,false,true,true,true,"{Forêt,""Destruction des habitats""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+incendies,true,false,false,true,false,false,true,true,false,"{""Destruction des habitats""}","{changement_climatique_consequences_indirectes,biodiversite_causes_indirectes}",fr
+intrants,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+milieu artificiel,true,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes_indirectes},fr
+mégot,true,false,false,true,false,false,false,true,true,"{Pollution,""Concepts généraux""}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+nouvelles techniques génomiques,true,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes_indirectes},fr
+ogm,true,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes_indirectes},fr
+organisme génétiquement modifiée,true,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes_indirectes},fr
+perturbateur endocrinien,true,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes_indirectes},fr
+plante exotique envahissante,true,false,false,true,false,false,true,true,false,"{Ecosystème,""Espèces exotiques envahissantes""}","{changement_climatique_consequences_indirectes,biodiversite_causes_indirectes}",fr
+plante exotique invasive,true,false,false,true,false,false,true,true,false,"{Ecosystème,""Espèces exotiques envahissantes""}","{changement_climatique_consequences_indirectes,biodiversite_causes_indirectes}",fr
+plante exotique très invasive,true,false,false,true,false,false,true,true,false,"{Ecosystème,""Espèces exotiques envahissantes""}","{changement_climatique_consequences_indirectes,biodiversite_causes_indirectes}",fr
+plastique,true,false,false,true,false,false,false,true,true,"{Pollution,""Economie circulaire""}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+plomb,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+pollue,true,false,false,true,false,false,true,true,true,"{Pollution,""Concepts généraux"",General}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+polluer,true,false,false,true,false,false,true,true,false,"{Pollution,General}","{changement_climatique_causes_indirectes,biodiversite_causes_indirectes}",fr
+pollution,true,false,false,true,false,false,true,true,false,"{Pollution,General}","{changement_climatique_causes_indirectes,biodiversite_causes_indirectes}",fr
+pollution de l’air,true,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes_indirectes},fr
+rejets industriels,true,false,false,true,false,false,false,true,false,{Pollution},{biodiversite_causes_indirectes},fr
+réchauffement,true,false,false,true,false,false,true,true,false,"{""Changement climatique""}","{changement_climatique_consequences_indirectes,biodiversite_causes_indirectes}",fr
+site minier,true,false,false,true,false,false,false,true,true,"{""Métaux et minerais"",General}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+solvant,true,false,false,true,false,false,true,true,true,"{Pollution,Eau,Industrie,Sols}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+surconsommation,true,false,false,true,false,false,false,true,true,"{""Concepts généraux"",General}","{ressources,biodiversite_causes_indirectes}",fr
+sécheresse,true,false,false,true,false,false,true,true,true,"{Eau,General}","{ressources,changement_climatique_consequences,biodiversite_causes_indirectes}",fr
+tourisme de masse,true,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes_indirectes},fr
+toxique,true,false,false,true,false,false,false,true,true,"{Pollution,""Concepts généraux""}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+trafic d’espèces,true,false,false,true,false,false,false,true,false,"{""Surexploitation des ressources""}",{biodiversite_causes_indirectes},fr
+urbanisation,true,false,false,true,false,false,false,true,false,"{""Destruction des habitats""}",{biodiversite_causes_indirectes},fr
+urbanisme,true,false,false,true,false,false,true,true,true,"{""Concepts généraux"",""Destruction des habitats"",General}","{changement_climatique_causes_indirectes,ressources_indirectes,biodiversite_causes_indirectes}",fr
+zinc,true,false,false,true,false,false,false,true,true,"{Pollution,Eau,Air,Sols}","{ressources_indirectes,biodiversite_causes_indirectes}",fr
+accord de kunming,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+accord de kunming-montréal,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+accord de montréal,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+ademe,false,true,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_solutions}",fr
+agence de l'eau,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+aire marine protégée,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+amnésie environnementale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+amphibien,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+animaux sauvages,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+anti-écolo,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+arbre remarquable,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+arnica,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+atteinte à la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+bien être animal,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+bien-être animal,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+bien-être de la nature,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+bio capacité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+biocapacité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+bios géo chimique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+bonne nouvelle pour la planète,false,true,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_solutions}",fr
+calotte du groenland,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+calotte glacière,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+calotte polaire,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+capacité planétaire,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+chauve-souris,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cigogne,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+coléoptères,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+consommation de plastique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+continuité écologique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+convention des nations unies sur la diversité biologique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+convention sur la diversité biologique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop 15,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop 16,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop de montréal,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop dix sept,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop quinze,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+cop seize,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop sur la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cop15,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+crise de la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+cycles biogéochimiques,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+d'ici 2050,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+destruction de la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+disparition des espèces,false,false,false,false,true,false,false,true,false,,"{biodiversite_concepts_generaux,biodiversite_consequences}",fr
+diversité biologique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+diversité des êtres vivants,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+diversité du vivant,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+déclin du vivant,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+dégradation de l'habitat,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+dégradation des ecosystèmes,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+empreinte biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+empreinte plastique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+enjeu environnemental,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+equilibre dynamique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+espèce animale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+espèce locale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+espèce migratrice,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+espèce végétale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+faune sauvage,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+fertilité des sols,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+flamant rose,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+fne,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+fnh,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+fondation pour la nature et l'homme,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+forêt boréale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+forêt tropicale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+france nature environnement,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+green deal,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+greenpeace,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+gypaète barbu,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+habitat naturel,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+habiter le monde,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_indirectes}",fr
+hot spot de biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+hydrologue,false,false,false,false,true,true,true,true,true,{Eau},"{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+impact environnementale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+interaction avec le vivant,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+intégrité écologique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+intérêt environnemental,false,true,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_solutions}",fr
+ipbes,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+journée mondiale de l'océan,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+journée mondiale des océans,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+libre évolution,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+lien au vivant,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+lien avec le vivant,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+lieu de ponte,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+ligue de protection des oiseaux,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+mammifère marin,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+mammifère terrestre,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+mangrove,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+milieu d'eau douce,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+milieu forestier,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+milieux naturels,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+mnhn,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+muséum d'histoire naturelle,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+mutation écologique,false,true,false,false,true,true,true,true,true,"{""Concepts généraux"",General}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_solutions}",fr
+mycorhize,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+mésange,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+métabolite,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+nappe phréatique,false,false,false,false,true,false,false,true,true,{Eau},"{biodiversite_concepts_generaux,ressources}",fr
+nidification,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+ofb,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+office français de la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+office national des forêts,false,false,false,false,true,true,true,true,true,{Forêt},"{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+pacte vert,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+patrimoine naturel,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+personnalité juridique des éléments naturels,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+photosynthèse,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+plage de ponte,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+plancton,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+planification écologique,false,true,false,false,true,true,true,true,true,"{""Concepts généraux"",General}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_solutions}",fr
+point chaud de biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+politique climatique,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+politique environnementale,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+pollinisateur,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+polliniser,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+protocole de montréal,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+relation au vivant,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+ressource planétaire,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+rouge gorge,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+réserve de chasse,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+résilience des écosystèmes,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+santé environnementale,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+sciences de l'environnement,false,true,false,false,true,true,true,true,true,"{""Concepts généraux"",General}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources_solutions}",fr
+service rendu par la nature,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+services écosystémiques,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+site de ponte,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+sixième extinction de masse,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+sommet sur la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+spécialiste de la biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+spécialiste des questions environnementales,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+stratégie nationale biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+séquestrer le carbone,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+tortue marine,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+tourbières,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+transition agro écologique,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+transition agroécologique,false,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux}",fr
+transition écologique,false,false,false,false,true,true,true,true,true,"{""Concepts généraux"",General}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+uicn,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+union internationale pour la conservation de la nature,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+ver de terre,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+vison d'europe,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+wwf,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+zone de biodiversité,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+zones humides,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+écologique,false,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_concepts_generaux,ressources}",fr
+écosystème aquatique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+écosystème forestier,false,false,false,false,true,false,false,true,true,{Forêt},"{biodiversite_concepts_generaux,ressources}",fr
+écosystème marin,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+écosystème montagnard,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+écosystèmes dégradés,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+écosystémique,false,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux},fr
+abeille,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+agences régionales de santé,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+agricole,true,false,false,true,true,false,true,true,false,{Agriculture},"{biodiversite_concepts_generaux_indirectes,changement_climatique_causes_indirectes}",fr
+agriculteur,true,false,false,true,true,false,true,true,false,{Agriculture},"{biodiversite_concepts_generaux_indirectes,changement_climatique_causes_indirectes}",fr
+agriculture,true,false,false,true,true,false,true,true,false,{Agriculture},"{biodiversite_concepts_generaux_indirectes,changement_climatique_causes_indirectes}",fr
+agroalimentaire,true,false,false,true,true,false,true,true,false,{Agriculture},"{biodiversite_concepts_generaux_indirectes,changement_climatique_causes_indirectes}",fr
+alimentation,true,false,false,false,true,true,true,true,true,"{""Concepts généraux"",Agriculture}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+anguille,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+arbre,true,true,false,false,true,true,true,true,true,{Forêt},"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+ars,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+autorité de santé,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+bactérie,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+biologiste,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+bloc d’immeubles,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+bocage,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+calotte,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+castor,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+cerf,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+champignon,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+chardonneret,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+chasse,true,false,false,false,true,false,false,true,true,{Forêt},"{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+chasseur,true,false,false,false,true,false,false,true,true,{Forêt},"{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+chevreuil,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+châtaignier,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+chêne,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+civelle,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+corail,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+coraux,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+cours d'eau,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+crise du lien,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+croissance bleue,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+croissance verte,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat,biodiversite_concepts_generaux_indirectes}",fr
+crustacé,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+dauphin,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+diversité génétique,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+déchetterie,true,false,false,false,true,false,false,true,true,"{""Economie circulaire""}","{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+dégrader,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+désertification,true,false,false,false,true,false,true,true,true,"{Eau,Sols}","{changement_climatique_consequences_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+eau,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+eau douce,true,false,false,false,true,false,false,true,true,{Eau},"{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+environnement,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+environnemental,true,false,false,false,true,false,false,true,true,"{""Concepts généraux""}","{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+environnementale,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+environnementaux,true,false,false,false,true,false,false,true,true,"{""Concepts généraux""}","{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+espèce,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+faune,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+flore,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+fourmi,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+frelon,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+genepi,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+guêpe,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+générations futures,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+générations à venir,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+habitat,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+hirondelle,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+humus,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+hérisson,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+hêtre,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+impact négatif,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+impact positif,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+impact sur la santé,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+incinérateur,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+insecte,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+irrigation,true,false,false,false,true,false,false,true,true,"{Eau,Sols}","{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+isard,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+izard,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+lac,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+le vivant,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+littoral,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+loup,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+lpo,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+lynx,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+mammifère,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+marais,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+mare,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+marmotte,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+marécage,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+mer,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+micro-organisme,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+microbe,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+milieu humide,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+milieu montagnard,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+ministre de la transition écologique,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+ministère de la transition écologique,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+modèle agricole,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+moineau,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+mollusque,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+montagne,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+moustique,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+nature,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+naturel,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+naturelle,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+nexus,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+non humain,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+océan,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+océanographe,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+oiseau,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+oms,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+one health,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+organisation mondiale de la santé,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+organisme vivant,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+ours,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+ours polaire,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+papillon,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+pelouse,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+pigeon,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+pins,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+planète,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+planétaire,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+poisson,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+pollinisation,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+pression,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+pêche professionnelle,true,false,false,false,true,false,false,true,true,{Eau},"{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+pêcheur,true,false,false,false,true,false,false,true,true,{Eau},"{biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+renard,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+revue nature,true,false,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+rivière,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+récif,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+récif corallien,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+sanglier,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+sapin,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+sargasse,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+saumon,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+sciences du vivant,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+termites,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+terre,true,false,false,false,true,true,true,true,true,"{""Concepts généraux"",Sols}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+tortue,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+tourbe,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+truite,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+une seule santé,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+vautour,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+vie sous-marine,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+virus,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+vivant,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+végétaux,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+zone humide,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+écolo,true,true,false,false,true,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_solutions_indirectes}",fr
+écologie,true,false,false,false,true,true,true,true,true,{Eau},"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes,ressources_indirectes}",fr
+écologiste,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+économie bleue,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+économie maritime,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+écosystème,true,false,false,false,true,true,true,true,false,,"{changement_climatique_constat_indirectes,biodiversite_concepts_generaux_indirectes}",fr
+écotourisme,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+écrevisse,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+éléphant,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+épicéa,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+étang,true,false,false,false,true,false,false,true,false,,{biodiversite_concepts_generaux_indirectes},fr
+acidification des océans,false,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences,biodiversite_consequences}",fr
+acidification du milieu marin,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+baisse de production agricole,false,false,false,false,false,false,true,true,true,"{Eau,Sols}","{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+baisse des rendements agricoles,false,false,false,false,false,false,true,true,true,"{Eau,Sols}","{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+baisse des récoltes,false,false,false,false,false,false,true,true,true,{Sols},"{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+baisse du stockage du carbone dans les sols,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+baleine échouée,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+biodiversité en danger,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+bioérosion,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+bruit routier,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+catastrophe écologique,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+condition dégradée d’habitation,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+crise d'extinction de masse,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+crise environnementale,false,false,false,false,false,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,ressources,biodiversite_consequences}",fr
+dauphin échoué,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+diminution des rendements agricoles,false,false,false,false,false,false,true,true,true,"{Eau,Sols}","{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+disparition des forêts,false,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences,biodiversite_consequences}",fr
+disparition des insectes,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+disparition des oiseaux,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+disparition du vivant,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+déclin de la biodiversité,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+dégradation des puits de carbone,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+dégradation des sols,false,false,false,false,false,false,false,true,true,{Sols},"{ressources,biodiversite_consequences}",fr
+espèce en voie de disparition,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+espèce envahissante,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+espèce exotique envahissante,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+espèce invasive,false,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences,biodiversite_consequences}",fr
+espèce menacée,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+espèce menacée d’extinction,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+espèce éteinte,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+espèces en danger,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+impact sur l'environnement,false,false,false,false,false,false,true,true,true,"{""Concepts généraux""}","{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+liste rouge de l'uicn,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+liste rouge mondiale des espèces menacées,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+mammifère échoué,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+migration des espèces,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+mortalité des forêts,false,false,false,false,false,false,false,true,true,{Forêt},"{ressources,biodiversite_consequences}",fr
+mortalité forestière,false,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences,biodiversite_consequences}",fr
+moustique tigre,false,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences,biodiversite_consequences}",fr
+nature empoisonnée,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+perte agricole,false,false,false,false,false,false,true,true,true,"{Eau,Sols}","{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+perte de biodiversité,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+perturbation des habitats,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+perturbation des écosystèmes,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+perturbation du cycle de l’eau,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+pollution sonore,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+polluée,false,false,false,false,false,false,false,true,true,"{""Concepts généraux""}","{ressources,biodiversite_consequences}",fr
+santé végétale,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+sol pollué,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+urgence écologique,false,false,false,false,false,false,true,true,true,"{""Concepts généraux""}","{ressources,changement_climatique_consequences,biodiversite_consequences}",fr
+zoonose,false,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences,biodiversite_consequences}",fr
+zoonotique,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+écosystème dégradé,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+érosion de la biodiversité,false,false,false,false,false,false,false,true,false,,{biodiversite_consequences},fr
+assécher,true,false,false,false,false,false,true,true,true,{Eau},"{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_consequences_indirectes}",fr
+asséché,true,false,false,false,false,false,true,true,true,{Eau},"{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_consequences_indirectes}",fr
+asséchée,true,false,false,false,false,false,true,true,true,{Eau},"{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_consequences_indirectes}",fr
+cancer,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+chant des oiseaux,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+contaminé,true,false,false,false,false,false,false,true,true,"{""Concepts généraux""}","{ressources_indirectes,biodiversite_consequences_indirectes}",fr
+contaminée,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+dengue,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+dépérissement,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+dévastation,true,false,false,false,false,false,true,true,false,{General},"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+exposition des salariés,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+extinction,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+les soulèvements de la terre,true,false,false,false,false,false,true,true,true,"{""Concepts généraux""}","{changement_climatique_consequences_indirectes,ressources_indirectes,biodiversite_consequences_indirectes}",fr
+malade,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+maladie,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+maladies infectieuses,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+maladies transmises par des insectes,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+menacées de disparition,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+pathologie,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+pollué,true,false,false,false,false,false,false,true,true,"{""Concepts généraux""}","{ressources_indirectes,biodiversite_consequences_indirectes}",fr
+problème sanitaire,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+prolifération des moustiques,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+risque sanitaire,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+santé animale,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+santé humaine,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+sécurité alimentaire,true,false,false,false,false,false,true,true,false,,"{changement_climatique_consequences_indirectes,biodiversite_consequences_indirectes}",fr
+échouage,true,false,false,false,false,false,false,true,false,,{biodiversite_consequences_indirectes},fr
+accueillir la faune,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+agriculture régénératrice,false,true,false,false,false,false,false,true,false,{Agriculture},{biodiversite_solutions},fr
+aire naturelle protégée,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+aires protégées,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+amoureux de la nature,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+amélioration des pratiques d’élevages,false,true,false,false,false,false,false,true,false,{Agriculture},{biodiversite_solutions},fr
+barrière végétale,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+bien-être des animaux,false,true,false,false,false,false,false,true,false,{Agriculture},{biodiversite_solutions},fr
+bioplastique,false,true,false,false,false,false,false,true,true,"{""Economie des ressources"",""Economie circulaire""}","{biodiversite_solutions,ressources_solutions}",fr
+changement transformateur,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+conservation de la nature,false,true,false,false,false,false,false,true,true,"{Ecosystème,""Concepts généraux""}","{biodiversite_solutions,ressources_solutions}",fr
+conserver la nature,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+corridor écologique,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+droit de l’environnement,false,true,false,false,false,false,false,true,false,{General},{biodiversite_solutions},fr
+défense de l'environnement,false,true,false,false,false,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_solutions,ressources_solutions}",fr
+défense de la nature,false,true,false,false,false,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_solutions,ressources_solutions}",fr
+défenseur de l'environnement,false,true,false,false,false,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_solutions,ressources_solutions}",fr
+défenseur de la nature,false,true,false,false,false,true,true,true,true,"{""Concepts généraux""}","{changement_climatique_constat,biodiversite_solutions,ressources_solutions}",fr
+emballage sans plastique,false,true,false,false,false,false,false,true,true,"{""Economie circulaire""}","{biodiversite_solutions,ressources_solutions}",fr
+espace naturel,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+espèce protégée,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+foncière forestière,false,true,false,false,false,false,false,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions}",fr
+gestion durable des ressources,false,true,false,false,false,false,false,true,true,"{""Concepts généraux""}","{biodiversite_solutions,ressources_solutions}",fr
+moins de fertilisant,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+nettoyage des fonds marins,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+nettoyage des océans,false,true,false,false,false,false,false,true,true,"{Ecosystème,Eau}","{biodiversite_solutions,ressources_solutions}",fr
+paillage naturel,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+pratiques agricoles durables,false,true,false,false,false,false,false,true,false,{Agriculture},{biodiversite_solutions},fr
+protection de l'environnement,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection de la barrière de corail,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection de la mangrove,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection de la nature,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection des coraux,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection des côtes,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection des espèces,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection des habitats,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+protection des oiseaux,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection des zones côtières,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection des zones humides,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protection du récif corallien,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protéger la nature,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protéger le vivant,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+protéger les habitats,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+préservation d'espèce,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+préservation de la biodiversité,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+préservation des milieux,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+préserver la biodiversité,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+préserver les fonds marins,false,true,false,false,false,false,false,true,true,"{Ecosystème,Eau}","{ressources,biodiversite_solutions}",fr
+préserver les sols,false,true,false,false,false,false,false,true,true,{Sols},"{biodiversite_solutions,ressources_solutions}",fr
+red ensauvagement,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+reduire les emballages,false,true,false,false,false,false,false,true,true,"{""Economie des ressources"",""Economie circulaire""}","{biodiversite_solutions,ressources_solutions}",fr
+respectueux de l'environnement,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration d'habitat,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+restauration de la biodiversité,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration de la nature,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration des coraux,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration des forêts,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration des habitats,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+restauration des milieux,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration des écosystèmes,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restauration du récif corallien,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restaurer la biodiversité,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restaurer la nature,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restaurer la qualité de l’air,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restaurer la qualité des sols,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+restaurer les habitats,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+ré ensauvagement,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+réintroduction d'espèce,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+réserve de biosphère,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+réserve naturelle,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+réserve sauvage,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+sauver des espèces,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+sciences participatives,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+sol vivant,false,true,false,false,false,false,false,true,true,"{Ecosystème,Sols}","{ressources,biodiversite_solutions}",fr
+solutions fondées sur la nature,false,true,false,false,false,false,false,true,false,{General},{biodiversite_solutions},fr
+trame verte,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+trame verte et bleu,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+lignite,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+transformation des pratiques agricoles,false,true,false,false,false,false,false,true,true,{Sols},"{biodiversite_solutions,ressources_solutions}",fr
+végétalisation des espaces urbains,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+végétalisation des villes,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+zone naturelle protégée,false,true,false,false,false,false,false,true,true,"{Ecosystème,Forêt}","{biodiversite_solutions,ressources_solutions}",fr
+zone sauvage,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+équilibre pour la faune et la flore,false,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions},fr
+éteindre l'éclairage public,false,true,false,false,false,false,false,true,false,,{biodiversite_solutions},fr
+agriculteur bio,true,true,false,false,false,false,false,true,true,{Sols},"{ressources_solutions_indirectes,biodiversite_solutions_indirectes}",fr
+compostable,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+infrastructure résiliente,true,true,false,false,false,false,false,true,false,{Batiments},{biodiversite_solutions_indirectes},fr
+manger bio,true,true,false,false,false,false,false,true,false,{Agriculture},{biodiversite_solutions_indirectes},fr
+nettoyage des plages,true,true,false,false,false,false,false,true,true,"{Ecosystème,Eau}","{ressources_solutions,biodiversite_solutions_indirectes}",fr
+parc national,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+parc naturel,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+toit-jardin,true,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions_indirectes},fr
+trame blanche,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+trame bleu,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+trame brune,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+trame noire,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+variété rustique,true,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions_indirectes},fr
+végétation,true,true,false,false,false,false,false,true,true,"{Sols,Forêt,General}","{ressources_indirectes,biodiversite_solutions_indirectes}",fr
+zan,true,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions_indirectes},fr
+zéro artificialisation nette,true,true,false,false,false,false,false,true,false,{Ecosystème},{biodiversite_solutions_indirectes},fr
+éteindre la lumière,true,true,false,false,false,false,false,true,false,,{biodiversite_solutions_indirectes},fr
+co deux,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+co2,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+combustibles fossiles,false,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes},fr
+dyoxide de carbone,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+ferme-usine,false,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes},fr
+fuel lourd,false,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes},fr
+fumée industrielle,false,false,false,true,false,false,true,false,false,{Industrie},{changement_climatique_causes},fr
+gaz à effet de serre,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+greenwashing,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+inaction climatique,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+insuffisance climatique,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+mauvaise nouvelle pour le climat,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+méthane,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+pollution industrielle,false,false,false,true,false,false,true,false,false,{Industrie},{changement_climatique_causes},fr
+élevage intensif,false,false,false,true,false,false,true,false,true,"{Eau,Agriculture,Sols}","{ressources,changement_climatique_causes}",fr
+émission de carbone,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+émissions anthropiques,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+émissions importées,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+émissions liées à la consommation,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+émissions territoriales,false,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes},fr
+énergies fossiles,false,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes},fr
+aliments transformés,true,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes_indirectes},fr
+automobile,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+autoroutes,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+aviation,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+avion,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+azote,true,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes_indirectes},fr
+carburant,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+charbon,true,false,false,true,false,false,true,false,true,{Energie},"{changement_climatique_causes_indirectes,ressources_indirectes}",fr
+chauffage,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+chauffage au fuel,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+chauffage au gaz,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+climatisation,true,false,false,true,false,false,true,false,false,{Batiments},{changement_climatique_causes_indirectes},fr
+diesel,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+déperdition de chaleur,true,false,false,true,false,false,true,false,false,{Batiments},{changement_climatique_causes_indirectes},fr
+emissions mondiales,true,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes_indirectes},fr
+essence,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+fioul,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+forage pétrolier,true,false,false,true,false,false,true,false,true,{Energie},"{changement_climatique_causes_indirectes,ressources_indirectes}",fr
+fuel,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+gaspillage alimentaire,true,false,false,true,false,false,true,false,false,"{""Economie des ressources""}",{changement_climatique_causes_indirectes},fr
+gaz,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+gaz carbonique,true,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes_indirectes},fr
+gaz de schiste,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+gaz naturel,true,false,false,true,false,false,true,false,true,{Energie},"{changement_climatique_causes_indirectes,ressources_indirectes}",fr
+industrialisation,true,false,false,true,false,false,true,false,true,"{""Concepts généraux"",Industrie}","{changement_climatique_causes_indirectes,ressources_indirectes}",fr
+industrie,true,false,false,true,false,false,true,false,false,{Industrie},{changement_climatique_causes_indirectes},fr
+infrastructures routières,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+kérosène,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+logement mal isolé,true,false,false,true,false,false,true,false,false,{Batiments},{changement_climatique_causes_indirectes},fr
+malbouffe,true,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes_indirectes},fr
+méga-camions,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+or noir,true,false,false,true,false,false,true,false,false,{Energie},{changement_climatique_causes_indirectes},fr
+passoire thermique,true,false,false,true,false,false,true,false,false,{Batiments},{changement_climatique_causes_indirectes},fr
+passoire énergétique,true,false,false,true,false,false,true,false,false,{Batiments},{changement_climatique_causes_indirectes},fr
+prendre l'avion,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+puit de pétrole,true,false,false,true,false,false,true,false,true,{Energie},"{changement_climatique_causes_indirectes,ressources_indirectes}",fr
+pétrole,true,false,false,true,false,false,true,false,true,{Energie},"{changement_climatique_causes_indirectes,ressources_indirectes}",fr
+secteur tertiaire,true,false,false,true,false,false,true,false,false,{General},{changement_climatique_causes_indirectes},fr
+serres chauffées,true,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes_indirectes},fr
+super-poids lourds,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+suv,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+trafic routier,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+transport,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+transport aérien,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+transport routier,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+transporteur,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+usine,true,false,false,true,false,false,true,false,false,{Industrie},{changement_climatique_causes_indirectes},fr
+vache,true,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes_indirectes},fr
+viande,true,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes_indirectes},fr
+voiture,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+voiture thermique,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+vol direct,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+vol paris new york,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+voyager,true,false,false,true,false,false,true,false,false,{Transport},{changement_climatique_causes_indirectes},fr
+élevage,true,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes_indirectes},fr
+élevage bovine,true,false,false,true,false,false,true,false,false,{Agriculture},{changement_climatique_causes_indirectes},fr
+îlot de chaleur,true,false,false,true,false,false,true,false,false,{Batiments},{changement_climatique_causes_indirectes},fr
+aléas climatiques,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+année la plus chaude,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+arrêt des centrales nucléaires,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+augmentation des précipitations,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+augmentation des risques de sécheresse,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+blanchissement des coraux,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+canicule,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+canicule marine,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+catastophe écologique,false,false,false,false,false,false,true,false,true,"{""Concepts généraux""}","{ressources,changement_climatique_consequences}",fr
+catastrophe climatique,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+chaleur extrême,true,false,false,false,false,false,true,false,true,{Eau},"{changement_climatique_consequences,ressources_indirectes}",fr
+chaleur record,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+chenille processionnaire,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+climatique extrême,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+conflit d’usage de l’eau,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+diminution de la banquise,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+diminution des glaciers,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+disparition des coraux,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+disparition des glaciers,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+disparition des récifs coralliens,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+décès à cause de la chaleur,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+déficit de pluie,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+déstabilisation atmosphérique,false,false,false,false,false,true,true,false,false,,"{changement_climatique_constat,changement_climatique_consequences}",fr
+effondrement de la falaise,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+fonte de la banquise,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+fonte des calottes glacières,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+fonte des glaces,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+fonte des glaciers,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+fonte du permafrost,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+glissement de terrain,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+hausse de la température du globe,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+hausse des températures,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+hausse du niveau de la mer,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+hausse du niveau des océans,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+hausse du niveau marin,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+inondations à répétition,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+intensification du cycle de l’eau,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+jour le plus chaud,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+l'hiver le plus chaud,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+l'hiver le plus sec,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+l'été le plus chaud,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+la planète se réchauffe,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+le climat du futur,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+les eaux se réchauffent,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+maladaptation,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+malle adaptation,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+manque d'eau,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+manquer d'eau,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+migrant climatique,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+migration climatique,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+montée des eaux,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+montée du niveau de la mer,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+montée du niveau des océans,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+mort liées à la canicule,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+mort liées à la chaleur,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+mort à cause de la canicule,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+mort à cause de la chaleur,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+morte à cause de la canicule,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+morte à cause de la chaleur,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+météorologique extrême,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+pénurie de neige,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+pollution aux particules fines,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+pollution à l’ozone,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+printemps le plus pluvieux,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+prolifération de moustiques,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+pénurie d'eau,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+rareté de la ressource en eau,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+rareté saisonnière de la ressource en eau,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+raréfaction de la ressource en eau,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+record de température,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+retrait gonflement des argiles,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+réfugié climatique,false,false,false,false,false,false,true,false,false,{General},{changement_climatique_consequences},fr
+salinisation des sols,false,false,false,false,false,false,true,false,true,"{Eau,Sols}","{ressources,changement_climatique_consequences}",fr
+stress hydrique,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+température extrême,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+température record,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+températures plus hautes,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+trop grande chaleur,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+vague de chaleur,false,false,false,false,false,false,true,false,true,{Eau},"{ressources,changement_climatique_consequences}",fr
+élévation de la température,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+élévation des températures,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+élévation du niveau de la mer,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+élévation du niveau des océans,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+élévation du niveau marin,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+érosion côtière,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+érosion des côtes,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+érosion du littoral,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+été le plus chaud,false,false,false,false,false,false,true,false,false,,{changement_climatique_consequences},fr
+40 degrés,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+50 degrés,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+accès à l’eau,true,false,false,false,false,false,true,false,true,{Eau},"{changement_climatique_consequences_indirectes,ressources}",fr
+anomalie de températures,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+augmentation des températures,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+catastrophe,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+cerné par les eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+cinquante degrés,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+crue,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+crue centennale,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+cyclone,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+déluge,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+eau boueuse,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+eaux boueuses,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+eaux déchainées,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+emporté par les eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+englouti par les eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+forte chaleur,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+forte pluie,true,false,false,false,false,false,true,false,true,{Eau},"{changement_climatique_consequences_indirectes,ressources_indirectes}",fr
+gel printanier,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+il n'y a plus de saison,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+importante précipitation,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+inondable,true,false,false,false,false,false,true,false,false,{Batiments},{changement_climatique_consequences_indirectes},fr
+inondation,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+l'eau est monté,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+l'eau qui est monté,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+la roya,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+les eaux sont montées,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+millimètre d'eau,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+mois le plus chaud,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+ouragan,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+piégé par les eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+pluie extrême,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+pluie intense,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+pluie torrentielle,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+plus chaud que la normale,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+plus chaude que la normale,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+plus de saisons,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+plus sec que la normale,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+pluviométrie importante,true,false,false,false,false,false,true,false,true,{Eau},"{changement_climatique_consequences_indirectes,ressources_indirectes}",fr
+pollution de l'air,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+période la plus chaude,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+quarante degrés,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+ruissellement de l'eau,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+ruissellement des eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+sous l'eau,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+sous les eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+submergé par les eaux,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+submersion,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+submersion marine,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+surchauffe,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+tempête xynthia,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+trop d'eau,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+très chaud,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+érosion,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+étouffer,true,false,false,false,false,false,true,false,false,,{changement_climatique_consequences_indirectes},fr
+accord de paris,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+anthropocène,false,false,false,false,false,true,true,false,true,"{""Concepts généraux""}","{changement_climatique_constat,ressources}",fr
+bilan carbone,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+climatique,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+climatologue,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+climatoscepticisme,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+conditions de vie sur terre,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+conférence climat,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+conférence des nations unies sur le climat,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+conférence des nations unies sur les changements climatiques,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+conférence des parties,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+convention des nations unies sur le climat,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop trente,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop vingt-et-un,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop vingt-huit,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop vingt-neuf,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop vingt-sept,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop vingt-six,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop21,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop26,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop27,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop28,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop29,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cop30,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+crise planétaire,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+crédit carbone,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+cycle du carbone,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+défi climatique,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+effet de serre,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+empreinte carbone,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+expert du climat,false,false,false,false,false,true,true,false,false,{General},{changement_climatique_constat},fr
+experte du climat,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+giec,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+habitabilité de la planète,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+haut conseil pour le climat,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+impact carbone,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+mix énergétique,false,false,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat,ressources}",fr
+méga-orage,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+neutralité carbone,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+neutralité climatique,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+pollution émise localement,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+revue nature climate change,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+réchauffement de l’atmosphère,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+réchauffement des océans,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+réchauffement des températures,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+réchauffement planétaire,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+scope un et deux,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+seuil de réchauffement,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+soutenabilité environnementale,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+transition agricole,false,false,false,false,false,true,true,false,false,{General},{changement_climatique_constat},fr
+transition climatique,false,false,false,false,false,true,true,false,false,{General},{changement_climatique_constat},fr
+transition en dehors des énergies fossiles,false,true,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat,ressources_solutions}",fr
+transition verte,false,false,false,false,false,true,true,false,false,{General},{changement_climatique_constat},fr
+transition énergétique,false,false,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat,ressources}",fr
+un climat qui change,false,false,false,false,false,true,true,false,false,,{changement_climatique_constat},fr
+émissions mondiales de co deux,false,false,false,false,false,true,true,false,false,{General},{changement_climatique_constat},fr
+émissions mondiales de co2,false,false,false,false,false,true,true,false,false,{General},{changement_climatique_constat},fr
+air frais,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+atmosphère,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+baisse des températures,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+banquise,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+batterie,true,false,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat_indirectes,ressources_indirectes}",fr
+bouquet énergétique,true,false,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat_indirectes,ressources_indirectes}",fr
+bâtiment,true,false,false,false,false,true,true,false,false,{Batiments},{changement_climatique_constat_indirectes},fr
+climat,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+climatosceptique,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+consommation énergétique,true,false,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat_indirectes,ressources_indirectes}",fr
+défi de notre siècle,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+eau de pluie,true,false,false,false,false,true,true,false,true,{Eau},"{changement_climatique_constat_indirectes,ressources_indirectes}",fr
+facture énergétique,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+fraîcheur,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+glacier,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+inégalité,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+jamais un tel phénomène,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+mix électrique,true,false,false,false,false,true,true,false,true,{Energie},"{changement_climatique_constat_indirectes,ressources_indirectes}",fr
+météo des forêts,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+ozone,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+performance énergétique,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+permafrost,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+pont thermique,true,false,false,false,false,true,true,false,false,{Batiments},{changement_climatique_constat_indirectes},fr
+santé publique,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+sol,true,false,false,false,false,true,true,false,true,{Sols},"{changement_climatique_constat_indirectes,ressources_indirectes}",fr
+température,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+zone inondable,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+éco-anxiété,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+énergie,true,false,false,false,false,true,true,false,false,,{changement_climatique_constat_indirectes},fr
+acidification des oceans,false,false,false,false,false,false,false,false,true,"{Eau,Sols}",{ressources},fr
+acidification des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+appauvrissement des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+bois énergie,false,false,false,false,false,false,false,false,true,"{Forêt,Energie}",{ressources},fr
+cobalt,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+compactage des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+conflits d’usage de l’eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+crise climatique,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+crise écologique,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+cycle de l’eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+dessalement de l’eau de mer,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+dépassement des limites planétaires,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+eau de ruissellement,false,false,false,false,false,false,false,false,true,"{Eau,Sols}",{ressources},fr
+eaux de ruissellement,false,false,false,false,false,false,false,false,true,"{Eau,Sols}",{ressources},fr
+eaux souterraines,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+engrais chimique,false,false,false,false,false,false,false,false,true,"{Eau,Air,Sols}",{ressources},fr
+eutrophisation,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+exploitation minière,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+exploration minière,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+fortes chaleurs,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+fumées industrielles,false,false,false,false,false,false,false,false,true,{air},{ressources},fr
+gestion des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+gestion forestière,false,false,false,false,false,false,false,false,true,{Forêt},{ressources},fr
+impact des emballages plastiques,false,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources},fr
+impact environnemental,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+industrie extractive,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+industrie minière,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+jour du dépassement,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+limites planétaires,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+manque d’eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+matière critique,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+matériaux polluants,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+mauvaise santé des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+minerais,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+minerais critiques,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+minerais stratégiques,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+modifier nos fonds marins,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+métal critique,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+métal rare,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+métaux critiques,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+métaux rares,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+nappe d'eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+politiques climatiques,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+pollution de l'eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+pollution des nappes,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+problème de sécurité alimentaire,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+pénurie d’eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+qualité de l'eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+qualité de l’eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+raréfaction de l’eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+rejet polluant,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+ressource en eau,true,false,false,false,false,false,false,false,true,{Eau},"{ressources,ressources_indirectes}",fr
+ressource minérale,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+ressource naturelle,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+ressource stratégique,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+ressources planétaires,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+réserve d'eau,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+salinisation des nappes,false,false,false,false,false,false,false,false,true,{Eau},{ressources},fr
+santé des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+sevrage aux énergies fossiles,false,false,false,false,false,false,false,false,true,{Energie},{ressources},fr
+sol appauvri,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+sol dégradé,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+sols pollués,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+surexploitation,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+surexploitation des ressources,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+surpâturage,false,false,false,false,false,false,false,false,true,"{Eau,Air,Sols}",{ressources},fr
+tassement des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+terre rare,false,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources},fr
+transformation écologique,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+trier ses déchets,false,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources},fr
+épuisement des ressources,false,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources},fr
+érosion des sols,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+érosion hydrique,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+érosion éolienne,false,false,false,false,false,false,false,false,true,{Sols},{ressources},fr
+abondance,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+acidification,true,false,false,false,false,false,false,false,true,"{Eau,Sols}",{ressources_indirectes},fr
+besoin énergétique,true,false,false,false,false,false,false,false,true,{Energie},{ressources_indirectes},fr
+compagnie gazière,true,false,false,false,false,false,false,false,true,{Energie},{ressources_indirectes},fr
+compagnie pétrolière,true,false,false,false,false,false,false,false,true,{Energie},{ressources_indirectes},fr
+cuivre,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+décharges,true,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_indirectes},fr
+déchets toxiques,true,false,false,false,false,false,false,false,true,"{Air,Forêt,Eau,Sols}",{ressources_indirectes},fr
+déchèterie,true,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_indirectes},fr
+eau absorbée,true,false,false,false,false,false,false,false,true,{Eau},{ressources_indirectes},fr
+eau potable,true,false,false,false,false,false,false,false,true,{Eau},{ressources_indirectes},fr
+eaux douces,true,false,false,false,false,false,false,false,true,{Eau},{ressources_indirectes},fr
+extraction,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+forestier,true,false,false,false,false,false,false,false,true,{Forêt},{ressources_indirectes},fr
+forestière,true,false,false,false,false,false,false,false,true,{Forêt},{ressources_indirectes},fr
+fuite d'eau,true,false,false,false,false,false,false,false,true,{Eau},{ressources_indirectes},fr
+gaspillage,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+gigantisme,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+gisement,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+gâchis,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+gâchis alimentaire,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+incendie,true,false,false,false,false,false,false,false,true,{Forêt},{ressources_indirectes},fr
+industrie pétrolière,true,false,false,false,false,false,false,false,true,{Energie},{ressources_indirectes},fr
+insécurité alimentaire,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+invendus,true,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_indirectes},fr
+jeter,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+lithium,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+manganèse,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+matière première,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+mauvaise gestion,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+mines,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+nature empoisonée,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+nickel,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+produit chimique,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+produit toxique,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+pénurie,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+ressource énergétique,true,false,false,false,false,false,false,false,true,{Energie},{ressources_indirectes},fr
+restes alimentaires,true,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_indirectes},fr
+restes de cantine,true,false,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_indirectes},fr
+ruisselement,true,false,false,false,false,false,false,false,true,"{Eau,Sols}",{ressources_indirectes},fr
+silicium,true,false,false,false,false,false,false,false,true,"{""Métaux et minerais""}",{ressources_indirectes},fr
+substance chimique,true,false,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_indirectes},fr
+suffoquer,true,false,false,false,false,false,false,false,true,"{Forêt,Sols}",{ressources_indirectes},fr
+uranium,true,false,false,false,false,false,false,false,true,{Energie},{ressources_indirectes},fr
+éco-sac wc,true,false,false,false,false,false,false,false,true,{Eau},{ressources_indirectes},fr
+bio,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+compost,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+composter,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+compostés,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+consigne,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+consommer autrement,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+durée de vie,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+manger mieux,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+mousseur,true,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions_indirectes},fr
+méga bassine,true,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions_indirectes},fr
+plantation,true,true,false,false,false,false,false,false,true,{Forêt},{ressources_solutions_indirectes},fr
+plus d'oxygène,true,true,false,false,false,false,false,false,true,{Air},{ressources_solutions_indirectes},fr
+pratique vertueuse,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+produits en vrac,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+produits locaux,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+rationnement,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+rationner,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+recyclable,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+recycle,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+réparation,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+se nourrir mieux,true,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions_indirectes},fr
+toilette sèche,true,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions_indirectes},fr
+toilette à double débit,true,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions_indirectes},fr
+tri,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+trier,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+vrac,true,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions_indirectes},fr
+économie d'énergie,true,true,false,false,false,false,false,false,true,{Energie},{ressources_solutions_indirectes},fr
+acv,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+analyse de cycle de vie,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+anti gaspi,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+baisse de consommation d'eau,false,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions},fr
+bio inspiration,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+biodéchets,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+bioinspiration,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+biomimétisme,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+circuits courts,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+déchet valorisé,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+fin de l'abondance,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+gaspiller moins,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+indice de réparabilité,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+jeter moins,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+lutte contre le gaspillage,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+maîtrise de la demande,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+moins consommer,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+moins gaspiller,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+moins jeter,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+partage des ressources,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+poubelle jaune,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+préservation des sols,false,true,false,false,false,false,false,false,true,{Sols},{ressources_solutions},fr
+préserver l'eau,false,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions},fr
+recyclerie,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+repair cafés,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+ressource renouvelable,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+récupérateur d’eau,false,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions},fr
+réduction des déchets,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+réduire la production de plastique,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+réparabilité,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+réutilisation des eaux,false,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions},fr
+réutilisation des ressources,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+stockage d’eau,false,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions},fr
+stocker l'eau,false,true,false,false,false,false,false,false,true,{Eau},{ressources_solutions},fr
+système alimentaire équitable,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+sécurité environnementale,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+tri des ordures,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+tri sélectif,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+un environnement alimentaire sain,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+zéro déchet,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+zéro emballage,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+écologie industrielle,false,true,false,false,false,false,false,false,true,"{""Concepts généraux""}",{ressources_solutions},fr
+économie du réemploi,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr
+éviter le plastique,false,true,false,false,false,false,false,false,true,"{""Economie circulaire""}",{ressources_solutions},fr

--- a/postgres/schemas/models.py
+++ b/postgres/schemas/models.py
@@ -321,10 +321,32 @@ def update_dictionary(engine, theme_keywords):
                     keyword_map[keyword] = {
                         'themes': set([theme]),  # Using sets to ensure uniqueness
                         'categories': set([category]) if category else set(),
-                        'data': item
+                        'data': item,
+                        'high_risk_of_false_positive': item.get('high_risk_of_false_positive'),
+                        'solution': item.get('solution'),
+                        'consequence': item.get('consequence'),
+                        'cause': item.get('cause'),
+                        'general_concepts': item.get('general_concepts'),
+                        'statement': item.get('statement'),
+                        'crisis_climate': item.get('crisis_climate'),
+                        'crisis_biodiversity': item.get('crisis_biodiversity'),
+                        'crisis_resource': item.get('crisis_resource'),
                     }
                 else:
                     # Already seen this keyword, update unique themes and categories
+                    keyword_map[keyword]['themes'].add(theme)
+
+                    # apply OR logic if already exists
+                    keyword_map[keyword]['high_risk_of_false_positive'] = keyword_map[keyword]['high_risk_of_false_positive'] or item.get('high_risk_of_false_positive')
+                    keyword_map[keyword]['solution'] = keyword_map[keyword]['solution'] or item.get('solution')
+                    keyword_map[keyword]['consequence'] = keyword_map[keyword]['consequence'] or item.get('consequence')
+                    keyword_map[keyword]['cause'] = keyword_map[keyword]['cause'] or item.get('cause')
+                    keyword_map[keyword]['general_concepts'] = keyword_map[keyword]['general_concepts'] or item.get('general_concepts')
+                    keyword_map[keyword]['statement'] = keyword_map[keyword]['statement'] or item.get('statement')
+                    keyword_map[keyword]['crisis_climate'] = keyword_map[keyword]['crisis_climate'] or item.get('crisis_climate')
+                    keyword_map[keyword]['crisis_biodiversity'] = keyword_map[keyword]['crisis_biodiversity'] or item.get('crisis_biodiversity')
+                    keyword_map[keyword]['crisis_resource'] = keyword_map[keyword]['crisis_resource'] or item.get('crisis_resource')
+
                     keyword_map[keyword]['themes'].add(theme)
                     if category:
                         keyword_map[keyword]['categories'].add(category)
@@ -334,17 +356,27 @@ def update_dictionary(engine, theme_keywords):
             item = data['data']
             themes = list(data['themes'])  # Convert set to list
             categories = list(data['categories'])  # Convert set to list
+            high_risk_of_false_positive = data['high_risk_of_false_positive']
+            solution = data['solution']
+            consequence = data['consequence']
+            cause = data['cause']
+            general_concepts = data['general_concepts']
+            statement = data['statement']
+            crisis_climate = data['crisis_climate']
+            crisis_biodiversity = data['crisis_biodiversity']
+            crisis_resource = data['crisis_resource']
+
             dictionary_entry = {
                 'keyword': keyword,
-                'high_risk_of_false_positive': item.get('high_risk_of_false_positive', True),
-                'solution': item.get('solution', False),
-                'consequence': item.get('consequence', False),
-                'cause': item.get('cause', False),
-                'general_concepts': item.get('general_concepts', False),
-                'statement': item.get('statement', False),
-                'crisis_climate': item.get('crisis_climate', True),
-                'crisis_biodiversity': item.get('crisis_biodiversity', True),
-                'crisis_resource': item.get('crisis_resource', True),
+                'high_risk_of_false_positive': high_risk_of_false_positive,
+                'solution': solution,
+                'consequence': consequence,
+                'cause': cause,
+                'general_concepts': general_concepts,
+                'statement': statement,
+                'crisis_climate': crisis_climate,
+                'crisis_biodiversity': crisis_biodiversity,
+                'crisis_resource': crisis_resource,
                 'categories': categories if categories else None,  # Use None if categories is empty
                 'themes': themes,
                 'language': item.get('language', 'fr')


### PR DESCRIPTION
fix pour ces champs qui n'étaient pas cohérent quand plusieurs mots clés avec des attributs différents (un seul prenait le dessus sur les autres)

-     d.high_risk_of_false_positive,
    d.solution,
    d.consequence,
    d.cause,
    d.general_concepts,
    d.statement,
    d.crisis_climate,
    d.crisis_biodiversity,
    d.crisis_resource,
    
  
## Todo in another PR
- [ ] remove crise_type de la core thematique --> remplacé par 3 booléen pour chaque type de crise
- [ ] remove category de la core thematique --> remplacé par categories
- [ ] remove theme de la core thematique --> remplacé par themes