### PR TITLE
385 add actual program durations

### DIFF
--- a/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
+++ b/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
@@ -4,155 +4,204 @@
   )
 }}
 
-    SELECT
-      pm.channel_title,
-      DATE_TRUNC('week', k.start) :: date AS week,
-      -- Dictionary metadata
-      d.high_risk_of_false_positive,
-      d.solution,
-      d.consequence,
-      d.cause,
-      d.general_concepts,
-      d.statement,
-      d.crisis_climate,
-      d.crisis_biodiversity,
-      d.crisis_resource,
-      d.categories,
-      d.themes,
-      d.language,
+with RECURSIVE weekly_expansion AS (
+-- Base case: get initial week_start for each row
+SELECT
+  pm.channel_title,
+  pm.country,
+  pm.channel_program,
+  pm.public,
+  pm.infocontinue,
+  pm.radio,
+  CAST(pm.program_grid_start AS TIMESTAMP) AS start_ts,
+  CAST(pm.program_grid_end AS TIMESTAMP) AS end_ts,
+  pm.duration_minutes,
+  DATE_TRUNC('week', CAST(pm.program_grid_start AS TIMESTAMP)) AS week_start
+FROM public.program_metadata pm
+UNION ALL
+-- Recursive case: add 1 week until week_start exceeds end_ts
+SELECT
+  we.channel_title,
+  we.country,
+  we.channel_program,
+  we.public,
+  we.infocontinue,
+  we.radio,
+  we.start_ts,
+  we.end_ts,
+  we.duration_minutes,
+  we.week_start + INTERVAL '7 days'
+FROM weekly_expansion we
+WHERE we.week_start + INTERVAL '7 days' <= we.end_ts
+),
+program_durations as (
+  SELECT
+    weekly_expansion.channel_title,
+    weekly_expansion.public,
+    weekly_expansion.infocontinue,
+    weekly_expansion.radio,
+    weekly_expansion.week_start,
+    SUM(weekly_expansion.duration_minutes) AS sum_duration_minutes_week
+  FROM weekly_expansion
+  where weekly_expansion.country = 'france'
+  GROUP BY
+    weekly_expansion.channel_title,
+    weekly_expansion.public,
+    weekly_expansion.infocontinue,
+    weekly_expansion.radio,
+    weekly_expansion.week_start
+),
+keywords_with_durations as (
+	select 
+	      k.*,
+	      DATE_TRUNC('week', k.start) :: date AS week_start,
+	      json_array_elements(k.keywords_with_timestamp :: json) AS kw,
+	      program_durations.sum_duration_minutes_week
+	from keywords k  
+	left join program_durations on k.channel_title=program_durations.channel_title and week_start=program_durations.week_start
+)
+select
+  pm.channel_title channel_title,
+  kd.week_start,
+  kd.sum_duration_minutes_week,
+  kd.channel_program,
+  kd.channel_name,
+  d.high_risk_of_false_positive,
+  d.solution,
+  d.consequence,
+  d.cause,
+  d.general_concepts,
+  d.statement,
+  d.crisis_climate,
+  d.crisis_biodiversity,
+  d.crisis_resource,
+  d.categories,
+  d.themes,
+  d.language,
+  CASE
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%solution%' THEN TRUE
+	ELSE FALSE
+  END AS is_solution,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%consequence%' THEN TRUE
+	  ELSE FALSE
+  END AS is_consequence,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%cause%' THEN TRUE
+	  ELSE FALSE
+  END AS is_cause,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%concepts_generaux%' THEN TRUE
+	  ELSE FALSE
+  END AS is_general_concepts,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%constat%' THEN TRUE
+	  ELSE FALSE
+  END AS is_statement,
+  category, --from dictionary table
+  -- Crise type selon le thème
+  CASE
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
+	ELSE 'Autre'
+  END AS crise_type,
+  kd.kw ->> 'theme' AS theme,
+ -- COALESCE(NULLIF(TRIM(kd.kw ->> 'category'), ''), 'Transversal') AS category, --legacy category would can be not up to date.
+  kd.kw ->> 'keyword' AS keyword,
+  COUNT(*) AS count
+from
+  keywords_with_durations kd
+left join public.program_metadata pm ON kd.channel_program = pm.channel_program
+  AND kd.channel_name = pm.channel_name
+  AND (
+    (
       CASE
-        WHEN LOWER(kw ->> 'theme') LIKE '%solution%' THEN TRUE
-        ELSE FALSE
-      END AS is_solution,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%consequence%' THEN TRUE
-          ELSE FALSE
-      END AS is_consequence,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%cause%' THEN TRUE
-          ELSE FALSE
-      END AS is_cause,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%concepts_generaux%' THEN TRUE
-          ELSE FALSE
-      END AS is_general_concepts,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%constat%' THEN TRUE
-          ELSE FALSE
-      END AS is_statement,
-	    category, --from dictionary table
-      -- Crise type selon le thème
-      CASE
-        WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
-        WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
-        WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
-        ELSE 'Autre'
-      END AS crise_type,
-      kw ->> 'theme' AS theme,
-     -- COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal') AS category, --legacy category would can be not up to date.
-      kw ->> 'keyword' AS keyword,
-      COUNT(*) AS count
-    FROM
-      public.keywords k
-     
-LEFT JOIN public.program_metadata pm ON k.channel_program = pm.channel_program
-     
-   AND k.channel_name = pm.channel_name
-      AND (
-        (
-          CASE
-            WHEN (
-              (
-                EXTRACT(
-                  DOW
-                  FROM
-                    k.start
-                ) :: int + 1 + 6
-              ) % 7
-            ) = 0 THEN 7
-            ELSE (
-              (
-                EXTRACT(
-                  DOW
-                  FROM
-                    k.start
-                ) :: int + 1 + 6
-              ) % 7
-            )
-          END = pm.weekday
+        WHEN (
+          (
+            EXTRACT(
+              DOW
+              FROM
+                kd.start
+            ) :: int + 1 + 6
+          ) % 7
+        ) = 0 THEN 7
+        ELSE (
+          (
+            EXTRACT(
+              DOW
+              FROM
+                kd.start
+            ) :: int + 1 + 6
+          ) % 7
         )
-      )
-      AND CAST(k.start AS date) BETWEEN CAST(pm.program_grid_start AS date)
-      AND CAST(pm.program_grid_end AS date) -- Expand keywords
-,
-      json_array_elements(k.keywords_with_timestamp :: json) AS kw -- Join dictionary on keyword
-      LEFT JOIN public.dictionary d ON d."keyword" = kw ->> 'keyword' -- Exclude indirect themes
-
-   -- Unnest categories array into one line per category
-    LEFT JOIN LATERAL UNNEST(
-        COALESCE(
-            d.categories,
-            ARRAY['Transversal']
-        )
-    ) AS category ON TRUE
-
-WHERE
-      LOWER(kw ->> 'theme') NOT LIKE '%indirect%'
-      AND k."country" = 'france'
-   
+      END = pm.weekday
+    )
+  )
+  AND CAST(kd.start AS date) BETWEEN CAST(pm.program_grid_start AS date) AND CAST(pm.program_grid_end AS date) -- Expand keywords
+LEFT JOIN public.dictionary d ON d."keyword" = kd.kw ->> 'keyword'
+-- Unnest categories array into one line per category
+LEFT JOIN LATERAL UNNEST(
+	COALESCE(
+		d.categories,
+		ARRAY['Transversal']
+	)
+) AS category ON TRUE
 GROUP BY
-      pm.channel_title,
-      DATE_TRUNC('week', k.start) :: date,
-      d.high_risk_of_false_positive,
-      d.solution,
-      d.consequence,
-      d.cause,
-      d.general_concepts,
-      d.statement,
-      d.crisis_climate,
-      d.crisis_biodiversity,
-      d.crisis_resource,
-      d.categories,
-      d.themes,
-      d.language,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%solution%' THEN TRUE
-          ELSE FALSE
-      END,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%consequence%' THEN TRUE
-          ELSE FALSE
-      END,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%cause%' THEN TRUE
-          ELSE FALSE
-      END,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%concepts_generaux%' THEN TRUE
-          ELSE FALSE
-      END,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%constat%' THEN TRUE
-          ELSE FALSE
-      END,
-      CASE
-          WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
-          WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
-          WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
-          ELSE 'Autre'
-      END,
-      CASE
-        WHEN LOWER(kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
-        WHEN LOWER(kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
-        WHEN LOWER(kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
-        ELSE 'Autre'
-      END,
-      kw ->> 'theme',
-      COALESCE(NULLIF(TRIM(kw ->> 'category'), ''), 'Transversal'),
-      kw ->> 'keyword',
-	    category
-   
+  pm.channel_title,
+  kd.week_start,
+  kd.sum_duration_minutes_week,
+  kd.channel_program,
+  kd.channel_name,
+  d.high_risk_of_false_positive,
+  d.solution,
+  d.consequence,
+  d.cause,
+  d.general_concepts,
+  d.statement,
+  d.crisis_climate,
+  d.crisis_biodiversity,
+  d.crisis_resource,
+  d.categories,
+  d.themes,
+  d.language,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%solution%' THEN TRUE
+	  ELSE FALSE
+  END,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%consequence%' THEN TRUE
+	  ELSE FALSE
+  END,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%cause%' THEN TRUE
+	  ELSE FALSE
+  END,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%concepts_generaux%' THEN TRUE
+	  ELSE FALSE
+  END,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%constat%' THEN TRUE
+	  ELSE FALSE
+  END,
+  CASE
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
+	  WHEN LOWER(kd.kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
+	  ELSE 'Autre'
+  END,
+  CASE
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%climat%' THEN 'Crise climatique'
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%biodiversite%' THEN 'Crise de la biodiversité'
+	WHEN LOWER(kd.kw ->> 'theme') LIKE '%ressource%' THEN 'Crise des ressources'
+	ELSE 'Autre'
+  END,
+  kd.kw ->> 'theme',
+  COALESCE(NULLIF(TRIM(kd.kw ->> 'category'), ''), 'Transversal'),
+  kd.kw ->> 'keyword',
+  category
 ORDER BY
-      pm.channel_title,
-      week,
-      crise_type
+  pm.channel_title,
+  week_start,
+  crise_type

--- a/my_dbt_project/models/schema.yml
+++ b/my_dbt_project/models/schema.yml
@@ -121,6 +121,8 @@ models:
         description: Title of the broadcast channel.
       - name: week
         description: Week of the observation (likely in YYYY-WW format).
+      - name: sum_duration_minutes_week
+        description: Number of program minutes for the week
       - name: crise_type
         description: Type of crisis being referenced.
       - name: theme
@@ -130,7 +132,7 @@ models:
       - name: keyword
         description: The keyword identified in the broadcast or transcript.
       - name: count
-        description: Count of lines or mentions related to the keyword.
+        description: Count of lines or mentions related to the keyword
 
   - name: core_query_thematics_keywords_i8n
     description: >


### PR DESCRIPTION
In order to add actual program durations to the evolution of keywords use over time we need to incluse the actual number of minutes per week per channel in the core_query_thematics_keywords materialised view.

This is done by adding the recursive select query present in Program Metadata - Weekly View to the dbt query for core_query_thematics_keywords.

The dbt schema is also updated.