### PR TITLE
fix: use CHANNEL to specific a channel to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,20 @@ docker compose up mediatree
 docker compose up test
 ```
 
+### docker secrets
+inside the "secrets" folder, you should have these 4 files, you can put dummy values or ask Quota Climat team for the real ones.
+```
+secrets: # https://docs.docker.com/compose/use-secrets/
+  pwd_api:
+    file: secrets/pwd_api.txt
+  username_api:
+    file: secrets/username_api.txt
+  bucket:
+    file: secrets/scw_bucket.txt
+  bucket_secret:
+    file: secrets/scw_bucket_secret.txt
+```
+
 If you add a new dependency, don't forget to rebuild
 ```
 docker compose build test # or ingest_to_db, mediatree etc

--- a/quotaclimat/data_processing/mediatree/api_import.py
+++ b/quotaclimat/data_processing/mediatree/api_import.py
@@ -142,9 +142,15 @@ async def get_and_save_s3_data_to_pg(exit_event):
 
                 # TODO : should we only trust data from S3 ?
                 df_programs = get_programs(country=country) # memory bumps ? should be lazy instead of being copied on each worker
-                channels = country.channels
 
-            
+                channel = os.environ.get("CHANNEL", "")
+                if channel != "":
+                    logging.warning(f"Using channel name {channel} only from env variable CHANNEL")
+                    channels = [channel]
+                else:
+                    logging.info(f"Using all channels for country {country.name} from config")
+                    channels = country.channels
+
                 stop_words = get_stop_words(session, validated_only=True, country=country)
                 
                 (start_date, number_of_previous_days) = get_start_time_to_query_from(session, country=country)


### PR DESCRIPTION
Reenable CHANNEL env variable to specifify a channel to import for the mediatree-job