### PR TITLE
fix(dbt): partition by month/year slow query "causal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ To update monthly our materialized view in production we have to use this comman
 poetry run dbt run --full-refresh
 ```
 
+#### Causal query - too slow
+Because this query is too massive, we set it month by month and avoid using a full-refresh. See units tests and docker-entrypoint.sh to see how.
+
 If we change the DBT code, we have to relaunch this command to have a refreshed view (or wait the next daily cron).
 
 ### SRT to Mediatree Format

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,5 +16,13 @@ fi
 echo "starting mediatree import app"
 python quotaclimat/data_processing/mediatree/api_import.py
 
-echo "apply dbt models full-refresh"
-poetry run dbt run --full-refresh # drop and recreate materialized views with the most up-to-date data.
+echo "apply dbt models"
+
+     # drop and recreate materialized views with the most up-to-date data.
+
+echo "apply dbt incremental model core_query_causal_links for each month"
+for m in {2022-01..2025-09}; do
+  echo "Processing month: $m"
+  poetry run dbt run -m core_query_causal_links --vars "{\"process_month\": \"$m-01\"}"
+done
+

--- a/my_dbt_project/models/dashboards/core_query_environmental_shares.sql
+++ b/my_dbt_project/models/dashboards/core_query_environmental_shares.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='incremental'
-    ,unique_key=['start','channel_title']
+    ,unique_key=['start','"Program Metadata - Channel Name__channel_title"']
   )
 }}
 

--- a/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
+++ b/my_dbt_project/pytest_tests/test_dbt_model_homepage.py
@@ -89,7 +89,7 @@ def run_thematic_query_ocean():
 @pytest.fixture(scope="module", autouse=True)
 def run_causal_links():
     """Run dbt for the causal links model once before related tests."""
-    commands = ["run", "--models", "core_query_causal_links", "--full-refresh","--debug"]
+    commands = ["run", "--models", "core_query_causal_links", "--vars", '{"process_month": "2025-02-01"}', "--full-refresh", "--debug"]
     logging.info(f"pytest running dbt core_query_causal_links {commands}")
 
     run_dbt_command(commands)


### PR DESCRIPTION
Slow query divided by month at first, then we'll switch to incremental runs without full refresh for it