### PR TITLE
fix column order

### DIFF
--- a/my_dbt_project/models/analytics/task_global_completion.sql
+++ b/my_dbt_project/models/analytics/task_global_completion.sql
@@ -117,8 +117,8 @@ env_shares as (
 	union all
 	select 
 		cqesin."start",
-		cqesin.channel_name,
 		cqesin.channel_title,
+		cqesin.channel_name,
 		cqesin.sum_duration_minutes,
 		cqesin."% climat" as weekly_perc_climat,
 		country


### PR DESCRIPTION
Inverted column names caused channel titles to be mixed with channel names