### PR TITLE
Genertate Annotation Version using created_at

### DIFF
--- a/my_dbt_project/models/analytics/task_global_completion.sql
+++ b/my_dbt_project/models/analytics/task_global_completion.sql
@@ -36,7 +36,7 @@ WITH choice_annotations AS (
 			elem ->> 'type' = 'choices'
 	) 
 	subquery ON true
-	GROUP BY task_completion_aggregate_id, task_aggregate_id
+	GROUP BY task_completion_aggregate_id, task_aggregate_id, created_at
 ),
 versioned_choices AS (
 	SELECT


### PR DESCRIPTION
Annotation Version is currently generated using the updated_at order, but creation order is the proper way to number versions.