### PR TITLE
Improve audio worker count calculation with memory constraints

### DIFF
--- a/quotaclimat/data_ingestion/advertising/s01_detection/processor.py
+++ b/quotaclimat/data_ingestion/advertising/s01_detection/processor.py
@@ -17,6 +17,45 @@ from .tools.common_objects import Chunk
 
 logger = logging.getLogger(__name__)
 
+MEM_PER_WORKER_MB = 200
+
+
+def _compute_num_workers() -> int:
+    """Compute safe worker count based on CPU and available memory.
+
+    In Docker, os.cpu_count() returns the *host* CPU count, which can lead
+    to spawning far too many workers for the container's memory budget.
+    Each audio-processing worker needs ~100-150 MB peak RAM, so we cap
+    the count based on available memory as well.
+
+    Set the AUDIO_WORKERS env var to override with a fixed value.
+    """
+    env_workers = os.environ.get("AUDIO_WORKERS")
+    if env_workers is not None:
+        n = max(1, int(env_workers))
+        logger.info("Worker count from AUDIO_WORKERS env var: %d", n)
+        return n
+
+    cpu_workers = max(1, os.cpu_count() - 2)
+
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    available_mb = int(line.split()[1]) / 1024  # kB -> MB
+                    mem_workers = max(1, int(available_mb / MEM_PER_WORKER_MB))
+                    n = min(cpu_workers, mem_workers)
+                    logger.info(
+                        "Worker count: %d (cpu_based=%d, mem_based=%d, available=%dMB)",
+                        n, cpu_workers, mem_workers, int(available_mb),
+                    )
+                    return n
+    except OSError:
+        pass
+
+    logger.info("Worker count: %d (cpu-based only, /proc/meminfo unavailable)", cpu_workers)
+    return cpu_workers
+
 
 # --- Signal-based pipeline (default, existing) ---
 
@@ -80,7 +119,7 @@ async def processor(
     #### Audio processing
 
     with timings.measure("audio_processing"):
-        new_workers = max(1, os.cpu_count() - 2)  # Laisser 1-2 CPUs libres pour l'OS
+        new_workers = _compute_num_workers()
 
         chunk_hash = chunk_creator.params_hash()
         with LocalCache(name="chunks", version=chunk_hash) as chunk_cache:


### PR DESCRIPTION
## Summary
Refactored worker count calculation for audio processing to account for both CPU and memory constraints, with support for manual override via environment variable.

## Key Changes
- Extracted worker count logic into a new `_compute_num_workers()` function that:
  - Respects the `AUDIO_WORKERS` environment variable for manual override
  - Calculates CPU-based worker count (cpu_count - 2)
  - Reads available memory from `/proc/meminfo` to calculate memory-based worker count
  - Takes the minimum of CPU and memory constraints to prevent OOM in containerized environments
  - Gracefully falls back to CPU-only calculation if `/proc/meminfo` is unavailable
  - Logs detailed information about worker count decisions for debugging

- Updated audio processing pipeline to use `_compute_num_workers()` instead of inline calculation

## Implementation Details
- Added `MEM_PER_WORKER_MB = 200` constant to define per-worker memory requirement (~100-150 MB peak + buffer)
- Addresses Docker container issue where `os.cpu_count()` returns host CPU count rather than container limit, potentially causing memory exhaustion
- Provides three configuration options in order of precedence:
  1. `AUDIO_WORKERS` environment variable (explicit override)
  2. Memory-constrained calculation (if `/proc/meminfo` available)
  3. CPU-only calculation (fallback)

https://claude.ai/code/session_01H3rGSNvej6FFJzWXWjWaGA