### PR TITLE
Add backpressure control to audio download worker

### DIFF
--- a/quotaclimat/data_ingestion/advertising/s01_detection/e01_download_audio.py
+++ b/quotaclimat/data_ingestion/advertising/s01_detection/e01_download_audio.py
@@ -86,6 +86,7 @@ class AudioProcessor:
         delete_files_after_processing: bool = True,
     ):
         self.num_workers = num_workers
+        self.max_concurrent_downloads = max_concurrent_downloads
         self.queue = asyncio.Queue(maxsize=max_queue_size)
 
         self.segments = list(segments)
@@ -155,10 +156,22 @@ class AudioProcessor:
         )
 
     async def _download_worker(self):
-        """Launch downloads and queue them as they complete"""
-        segments = [self._download_and_queue(segment) for segment in self.segments]
+        """Download segments with backpressure from the processing queue.
 
-        await asyncio.gather(*segments)
+        The inflight semaphore wraps the entire download+enqueue as one unit.
+        A new download only starts once a previous one has been enqueued,
+        so when the queue is full, downloads pause instead of piling up files on disk.
+        Max files on disk ≈ max_concurrent_downloads + max_queue_size + num_workers.
+        """
+        inflight = asyncio.Semaphore(self.max_concurrent_downloads)
+
+        async def _bounded_download(segment: Segment):
+            async with inflight:
+                await self._download_and_queue(segment)
+
+        async with asyncio.TaskGroup() as tg:
+            for segment in self.segments:
+                tg.create_task(_bounded_download(segment))
 
         for _ in range(self.num_workers):
             await self.queue.put(None)


### PR DESCRIPTION
## Summary
Implement concurrent download limiting in the audio download worker to prevent excessive disk usage by controlling how many downloads can be in-flight simultaneously.

## Key Changes
- Store `max_concurrent_downloads` as an instance variable for use in the download worker
- Replace simple `asyncio.gather()` with a semaphore-based approach to limit concurrent downloads
- Use `asyncio.TaskGroup` for structured concurrency instead of manually gathering tasks
- Wrap each download operation with a semaphore to enforce the concurrency limit

## Implementation Details
The new implementation uses an `asyncio.Semaphore` to bound the number of concurrent downloads. The semaphore wraps the entire download+enqueue operation as a single unit, ensuring that:
- Downloads pause when the processing queue is full, providing backpressure
- Files don't accumulate excessively on disk during processing
- Maximum files on disk is approximately `max_concurrent_downloads + max_queue_size + num_workers`

This replaces the previous approach where all downloads would be initiated immediately, potentially causing memory and disk pressure when the processing queue couldn't keep up.

https://claude.ai/code/session_018WvPApAAK3KLPj97XnbvCW