### PR TITLE
[FIX] Distinguish belgium instances in requests

### DIFF
--- a/quotaclimat/data_processing/mediatree/api_import_utils/db.py
+++ b/quotaclimat/data_processing/mediatree/api_import_utils/db.py
@@ -33,7 +33,8 @@ def get_last_date_and_number_of_delay_saved_in_keywords(session: Session, days_f
             .where(
                 and_(
                     Keywords.start >= func.now() - text(f"INTERVAL '{days_filter} days'"),
-                    Keywords.country == country.name
+                    Keywords.country == country.name,
+                    Keywords.channel_name.in_(country.channels),
                 )
             )
             .subquery("source")

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -228,7 +228,8 @@ def get_keywords_columns(session: Session, offset: int = 0, batch_size: int = 50
         and_(
             func.date(Keywords.start) >= start_date, 
             func.date(Keywords.start) <= end_date,
-            Keywords.country == country.name
+            Keywords.country == country.name,
+            Keywords.channel_name.in_(country.channels),
         )
     ).order_by(Keywords.start, Keywords.channel_name, Keywords.plaintext)
 
@@ -272,7 +273,12 @@ def get_total_count_saved_keywords(session: Session, start_date : str, end_date 
         if channel != "":
             statement = statement.filter(Keywords.channel_name == channel)
         
-        statement = statement.filter(Keywords.country == country.name)
+        statement = statement.filter(
+            and_(
+                Keywords.country == country.name,
+                Keywords.channel_name.in_(country.channels),
+            )
+        )
         
         if empty_program_only:
             statement = statement.filter(

--- a/test/mediatree/test_mediatree_queries.py
+++ b/test/mediatree/test_mediatree_queries.py
@@ -29,7 +29,7 @@ def test_mediatree_get_last_date_and_number_of_delay_saved_in_keywords():
         "id" : pk,
         "start": start,
         "plaintext": "test",
-        "channel_name": "test",
+        "channel_name": "france2",
         "channel_radio": False,
         "theme":[],
         "keywords_with_timestamp": [],


### PR DESCRIPTION
As belgium-francophone and belgium-dutch both have the same country.name attribute, when running jobs we need to filter on the channels to distinguish the two.