### PR TITLE
Migrate orchestrator from VM to Elastic Metal (EM-A610R-NVMe)

### DIFF
--- a/infrastructure/Readme.md
+++ b/infrastructure/Readme.md
@@ -24,11 +24,11 @@ infrastructure/
 │   ├── advertising/           # Label Studio + advertising detection infra
 │   ├── barometre/              # Barometre database infra
 │   ├── rrs/                   # RRS database + serverless jobs
-│   └── orchestrator/          # Kestra + GlitchTip VM (single shared instance)
+│   └── orchestrator/          # Kestra + GlitchTip Elastic Metal server (single shared instance)
 │       ├── prod/
 │       │   └── terragrunt.hcl
 │       └── template/
-│           ├── instance.tf    # VM, security group, SSH key, IP
+│           ├── instance.tf    # Elastic Metal server (EM-A610R-NVMe), SSH keys, offer/OS
 │           ├── database.tf    # Kestra + GlitchTip databases on managed PG
 │           ├── variables.tf
 │           └── outputs.tf
@@ -154,7 +154,7 @@ cp inventory.yml.j2 inventory.yml
 
 ## Orchestrator deployment
 
-The orchestrator VM hosts [Kestra](https://kestra.io) (workflow orchestration) and [GlitchTip](https://glitchtip.com) (error tracking), fronted by Traefik with automatic TLS.
+The orchestrator runs on a Scaleway **Elastic Metal** bare-metal server (EM-A610R-NVMe) hosting [Kestra](https://kestra.io) (workflow orchestration) and [GlitchTip](https://glitchtip.com) (error tracking), fronted by Traefik with automatic TLS. Docker data lives on the local NVMe (no attached block volume), and the firewall is UFW only (Elastic Metal has no Scaleway security group).
 
 Unlike other targets, the orchestrator is a **single shared instance** — there is no dev/prod split. Kestra uses namespaces to separate environments, and GlitchTip uses projects.
 
@@ -168,7 +168,7 @@ make setup
 cp .env.dist .env                    # Add SCW_ACCESS_KEY / SCW_SECRET_KEY
 make sync-secrets                    # Or: cp .env.secrets.dist .env.secrets
 
-# 3. Provision infrastructure (VM + databases)
+# 3. Provision infrastructure (Elastic Metal server + databases)
 make env=prod target=orchestrator tg-init
 make env=prod target=orchestrator tg-plan
 make env=prod target=orchestrator tg-apply
@@ -178,8 +178,11 @@ make env=prod target=orchestrator tg-output
 cd ansible && cp inventory.yml.j2 inventory.yml
 # Edit inventory.yml: replace {{ instance_ip }} with the actual IP
 
-# 5. Point DNS records to the VM IP
-#    traefik.<domain>, kestra.<domain>, glitchtip.<domain>
+# 5a. Allow-list the server IP on the managed PG (rdb-poc) ACL — Scaleway console
+#     (rdb-poc's ACL is managed outside this repo). On migration, remove the old IP.
+
+# 5b. Point DNS records to the server IP
+#     traefik.<domain>, kestra.<domain>, glitchtip.<domain>
 
 # 6. Deploy services
 cd .. && make ansible

--- a/infrastructure/ansible/roles/common/tasks/main.yml
+++ b/infrastructure/ansible/roles/common/tasks/main.yml
@@ -98,7 +98,7 @@
     - { key: net.ipv4.tcp_syncookies, value: "1" }
     - { key: net.ipv4.conf.all.log_martians, value: "1" }
 
-# --- Firewall (belt + suspenders with Scaleway security group) ---
+# --- Firewall (UFW is the sole firewall — Elastic Metal has no Scaleway security group) ---
 
 - name: Set UFW default deny incoming
   community.general.ufw:

--- a/infrastructure/live/orchestrator/prod/terragrunt.hcl
+++ b/infrastructure/live/orchestrator/prod/terragrunt.hcl
@@ -7,8 +7,7 @@ terraform {
 }
 
 inputs = {
-  # VM
-  instance_type = "DEV1-M"
+  # Elastic Metal server defaults (offer/zone/os) live in variables.tf; override here if needed.
 
   # Managed Postgres (reuse existing barometre instance)
   pg_instance_name = get_env("TF_VAR_pg_instance_name", "rdb-poc")

--- a/infrastructure/live/orchestrator/template/instance.tf
+++ b/infrastructure/live/orchestrator/template/instance.tf
@@ -4,77 +4,57 @@ resource "scaleway_account_project" "project" {
   name = "orchestrator"
 }
 
-# --- Security Group ---
+# --- SSH keys ---
+# Elastic Metal installs the OS with these keys baked in (no flexible IP / no
+# Scaleway auto-injection like instances). Public keys mirror the deploy keys the
+# ansible `ssh-keys` role manages on the host.
 
-resource "scaleway_instance_security_group" "orchestrator" {
-  name                    = "orchestrator"
-  project_id              = scaleway_account_project.project.id
-  inbound_default_policy  = "drop"
-  outbound_default_policy = "accept"
-
-  # SSH
-  inbound_rule {
-    action   = "accept"
-    port     = 22
-    protocol = "TCP"
-  }
-
-  # HTTP (for Let's Encrypt ACME challenge)
-  inbound_rule {
-    action   = "accept"
-    port     = 80
-    protocol = "TCP"
-  }
-
-  # HTTPS
-  inbound_rule {
-    action   = "accept"
-    port     = 443
-    protocol = "TCP"
-  }
+resource "scaleway_iam_ssh_key" "paul" {
+  name       = "orchestrator-paul"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBXjyIJ/Kp3iSV10p+zZcPSXVqk/1CMbyY9z89XdijhM paul@dataforgood.fr"
 }
 
-# --- Instance ---
-
-resource "scaleway_instance_ip" "orchestrator" {
-  project_id = scaleway_account_project.project.id
+resource "scaleway_iam_ssh_key" "gmguarino" {
+  name       = "orchestrator-gmguarino"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIOIZMzVkOuJVUb31YAGMhiKksvLc8r6kqcBMxRPr37l gmguarino1@gmail.com"
 }
 
-resource "scaleway_instance_server" "orchestrator" {
+# --- Bare-metal server (Elastic Metal) ---
+
+data "scaleway_baremetal_offer" "orchestrator" {
+  zone = var.zone
+  name = var.offer_name
+}
+
+data "scaleway_baremetal_os" "orchestrator" {
+  zone    = var.zone
+  name    = var.os_name
+  version = var.os_version
+}
+
+resource "scaleway_baremetal_server" "orchestrator" {
   name       = "orchestrator"
+  zone       = var.zone
   project_id = scaleway_account_project.project.id
-  type       = var.instance_type
-  image      = var.instance_image
 
-  ip_id             = scaleway_instance_ip.orchestrator.id
-  security_group_id = scaleway_instance_security_group.orchestrator.id
+  offer = data.scaleway_baremetal_offer.orchestrator.id
+  os    = data.scaleway_baremetal_os.orchestrator.id
 
-  # Minimal cloud-init: install Python for Ansible
-  user_data = {
-    cloud-init = <<-EOF
-      #cloud-config
-      package_update: true
-      packages:
-        - python3
-        - python3-apt
-    EOF
-  }
+  ssh_key_ids = [
+    scaleway_iam_ssh_key.paul.id,
+    scaleway_iam_ssh_key.gmguarino.id,
+  ]
+
+  # Elastic Metal has no instance security group — UFW (ansible common role) is
+  # the firewall. Storage is the local NVMe (no attachable block volume).
+  # Minimal cloud-init so Ansible has Python available.
+  cloud_init = <<-EOF
+    #cloud-config
+    package_update: true
+    packages:
+      - python3
+      - python3-apt
+  EOF
 
   tags = ["orchestrator"]
-}
-
-# --- Block storage for Docker data ---
-
-resource "scaleway_block_volume" "data" {
-  name       = "orchestrator-data"
-  project_id = scaleway_account_project.project.id
-  iops       = 5000
-  size_in_gb = var.data_volume_size
-}
-
-resource "scaleway_block_snapshot" "data" {
-  name      = "orchestrator-data-snapshot"
-  volume_id = scaleway_block_volume.data.id
-
-  count = 0 # enable later for scheduled snapshots
 }

--- a/infrastructure/live/orchestrator/template/outputs.tf
+++ b/infrastructure/live/orchestrator/template/outputs.tf
@@ -1,9 +1,5 @@
 output "instance_ip" {
-  value = scaleway_instance_ip.orchestrator.address
-}
-
-output "data_volume_id" {
-  value = scaleway_block_volume.data.id
+  value = scaleway_baremetal_server.orchestrator.ipv4[0].address
 }
 
 output "postgres_host" {

--- a/infrastructure/live/orchestrator/template/variables.tf
+++ b/infrastructure/live/orchestrator/template/variables.tf
@@ -1,20 +1,27 @@
-# --- VM ---
+# --- Bare-metal server (Elastic Metal) ---
 
-variable "instance_type" {
-  type    = string
-  default = "DEV1-M"
-}
-
-variable "instance_image" {
+variable "zone" {
   type        = string
-  default     = "ubuntu_noble"
-  description = "Scaleway image label (e.g. ubuntu_noble, debian_bookworm)."
+  default     = "fr-par-2"
+  description = "Scaleway zone for the Elastic Metal server (must stock the offer)."
 }
 
-variable "data_volume_size" {
-  type        = number
-  default     = 100
-  description = "Size in GB of the block storage volume for Docker data."
+variable "offer_name" {
+  type        = string
+  default     = "EM-A610R-NVMe"
+  description = "Elastic Metal offer name (data.scaleway_baremetal_offer)."
+}
+
+variable "os_name" {
+  type        = string
+  default     = "Ubuntu"
+  description = "Elastic Metal OS name (data.scaleway_baremetal_os)."
+}
+
+variable "os_version" {
+  type        = string
+  default     = "24.04 LTS (Noble Numbat)"
+  description = "Elastic Metal OS version string, must match the Scaleway catalog exactly."
 }
 
 # --- Managed Postgres ---


### PR DESCRIPTION
## What & why

Moves the orchestrator (Kestra + GlitchTip + Traefik) off the small Scaleway **VM** (`scaleway_instance_server`, DEV1-M) onto a Scaleway **Elastic Metal** bare-metal server **EM-A610R-NVMe** (AMD Ryzen 5 PRO 3600, 6c/12t, 32 GB RAM, NVMe) for more headroom.

## Changes (`infrastructure/`)

- **`live/orchestrator/template/instance.tf`** — rewritten around `scaleway_baremetal_server` (offer/OS via `scaleway_baremetal_offer`/`scaleway_baremetal_os` data sources, `zone`), plus two `scaleway_iam_ssh_key` resources built from the deploy public keys already in the `ssh-keys` role (Elastic Metal needs SSH keys at install). Minimal `cloud_init` installs `python3` for Ansible. **Removed** the security group, flexible IP, and block volume + snapshot — Elastic Metal has no instance SG and uses local NVMe.
- **`variables.tf`** — `instance_type`/`instance_image`/`data_volume_size` → `zone`/`offer_name`/`os_name`/`os_version`.
- **`outputs.tf`** — `instance_ip` now from `ipv4[0].address`; dropped `data_volume_id` (output name kept so the inventory template + runbook still work).
- **`prod/terragrunt.hcl`** — dropped `instance_type`.
- **`ansible/roles/common/tasks/main.yml`** — firewall comment now reflects UFW being the sole firewall.
- **`Readme.md`** — orchestrator section updated (Elastic Metal, local NVMe) + the manual ACL/DNS steps.

`database.tf` is **unchanged** — Kestra/GlitchTip databases stay on the shared managed Postgres `rdb-poc`.

## Decisions (agreed)

- **In-place replace** — the VM is destroyed and the bare metal created in one apply (accepted: short downtime + new IP).
- **Keep the managed Postgres** `rdb-poc` (durable state untouched; allow-list the new IP).
- **Clean redeploy** — no `/opt/services` migration (Kestra exec files, GlitchTip media, `acme.json` not carried over; Let's Encrypt re-issues certs).

## Operator steps after merge (not automated)

1. `make env=prod target=orchestrator tg-plan` — confirm: **create** baremetal server + 2 SSH keys, **destroy** VM + IP + SG + block volume; `database.tf` unchanged.
2. `tg-apply` (downtime here) → `tg-output` for the new IP.
3. **Allow-list the new IP on `rdb-poc`'s ACL** (managed in the Scaleway console, outside this repo) and remove the old VM IP.
4. **Repoint DNS** (traefik/kestra/glitchtip) to the new IP.
5. Render `ansible/inventory.yml` with the new IP, then `make ansible`.

## Confirm at `tg-plan` time

- **Zone** defaults to `fr-par-2`; if EM-A610R-NVMe isn't stocked there the offer data source errors → try `fr-par-1`.
- **`os_version`** must match Scaleway's catalog exactly (`"24.04 LTS (Noble Numbat)"`); if a `scaleway_iam_ssh_key` already exists in the org, `tofu import` it.