### PR TITLE
Fix Ansible SSH login; add RRS read-only DB user and dev Kestra flow fixes

### DIFF
--- a/infrastructure/ansible/inventory.yml.j2
+++ b/infrastructure/ansible/inventory.yml.j2
@@ -5,5 +5,5 @@ all:
   hosts:
     orchestrator:
       ansible_host: {{ instance_ip }}
-      ansible_user: root
+      ansible_user: ubuntu
       ansible_ssh_extra_args: -o ControlPath=none

--- a/infrastructure/ansible/playbook.yml
+++ b/infrastructure/ansible/playbook.yml
@@ -33,6 +33,7 @@
 
     # Kestra secrets (for flow execution)
     kestra_secrets:
+      API_LABEL_STUDIO_KEY: "{{ lookup('env', 'API_LABEL_STUDIO_KEY') }}"
       ANTHROPIC_API_KEY: "{{ lookup('env', 'ANTHROPIC_API_KEY') }}"
       LABELSTUDIO_INGESTION_POSTGRES_USER: "{{ lookup('env', 'LABELSTUDIO_INGESTION_POSTGRES_USER') }}"
       LABELSTUDIO_INGESTION_POSTGRES_PASSWORD: "{{ lookup('env', 'LABELSTUDIO_INGESTION_POSTGRES_PASSWORD') }}"
@@ -43,6 +44,8 @@
       POSTGRES_HOST: "{{ lookup('env', 'BAROMETRE_POSTGRES_HOST') }}"
       POSTGRES_PASSWORD: "{{ lookup('env', 'BAROMETRE_POSTGRES_PASSWORD') }}"
       POSTGRES_USER: "{{ lookup('env', 'BAROMETRE_POSTGRES_USER') }}"
+      POSTGRES_PASSWORD_READ: "{{ lookup('env', 'BAROMETRE_POSTGRES_PASSWORD_READ') }}"
+      POSTGRES_USER_READ: "{{ lookup('env', 'BAROMETRE_POSTGRES_USER_READ') }}"
       RRS_PG_HOST: "{{ lookup('env', 'RRS_PG_HOST') }}"
       RRS_PG_PASSWORD: "{{ lookup('env', 'RRS_PG_PASSWORD') }}"
       RRS_PG_USER: "{{ lookup('env', 'RRS_PG_USER') }}"
@@ -52,6 +55,7 @@
 
     # Kestra secrets (for flow execution)
     kestra_secrets_dev:
+      API_LABEL_STUDIO_KEY_DEV: "{{ lookup('env', 'API_LABEL_STUDIO_KEY_DEV') }}"
       POSTGRES_HOST_DEV: "{{ lookup('env', 'BAROMETRE_POSTGRES_HOST_DEV') }}"
       POSTGRES_PASSWORD_DEV: "{{ lookup('env', 'BAROMETRE_POSTGRES_PASSWORD_DEV') }}"
       POSTGRES_USER_DEV: "{{ lookup('env', 'BAROMETRE_POSTGRES_USER_DEV') }}"

--- a/infrastructure/ansible/playbook.yml
+++ b/infrastructure/ansible/playbook.yml
@@ -1,6 +1,7 @@
 ---
 - name: Provision orchestrator VM
   hosts: orchestrator
+  remote_user: ubuntu
   become: true
 
   vars:

--- a/infrastructure/kestra/flows/main_quotaclimatdev_barometre.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimatdev_barometre.yaml
@@ -14,9 +14,9 @@ tasks:
       - /bin/sh
       - -c
       - cd /app && python /app/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
-    shmSize: 2gb
+    shmSize: 10gb
     env: 
-      API_TO_S3_CONCURRENCY: 3
+      API_TO_S3_CONCURRENCY: 10
       BUCKET_NAME: test-bucket-mediatree
       COUNTRY: fra
       ENV: prod
@@ -35,6 +35,7 @@ tasks:
       SENTRY_DSN: "{{ secret('SENTRY_DSN') }}"
 
   - id: detect_keywords
+    logLevel: WARN          # filter per-row INFO spam at the Kestra level (UI freeze fix)
     shmSize: 2gb
     type: io.kestra.plugin.docker.Run
     containerImage: "rg.fr-par.scw.cloud/namespace-barometre/quotaclimat_base:latest"
@@ -77,13 +78,15 @@ tasks:
       SENTRY_DSN: "{{ secret('SENTRY_DSN') }}"
 
   - id: detect_misinformation
+    logLevel: WARN          # filter per-row INFO spam at the Kestra level (UI freeze fix)
     shmSize: 2gb
     type: io.kestra.plugin.docker.Run
     containerImage: "rg.fr-par.scw.cloud/misinformation/label-misinformation:latest"
     pullPolicy: ALWAYS
     credentials:
       registry: rg.fr-par.scw.cloud/misinformation
-      registryToken: "{{ secret('SCW_SECRET') }}"
+      username: nologin
+      password: "{{ secret('SCW_SECRET') }}"
     entryPoint:
       - /bin/sh
       - -c
@@ -106,16 +109,16 @@ tasks:
       MODEL_NAME: ft:gpt-4o-mini-2024-07-18:personal::B1xWiJRm
       MODIN_MEMORY: 2000000000
       POSTGRES_DB: barometre
-      POSTGRES_PORT: 17975
+      POSTGRES_PORT: 22737
       RAY_COLOR_PREFIX: 1
       API_LABEL_STUDIO_KEY: "{{ secret('API_LABEL_STUDIO_KEY_DEV') }}"
       BUCKET_ACCESS: "{{ secret('SCW_ACCESS') }}"
       BUCKET_SECRET: "{{ secret('SCW_SECRET') }}"
       MEDIATREE_PASSWORD: "{{ secret('MEDIATREE_PASSWORD') }}"
       OPENAI_API_KEY: "{{ secret('OPENAI_API_KEY') }}"
-      POSTGRES_HOST: "{{ secret('POSTGRES_HOST_DEV') }}"
-      POSTGRES_PASSWORD: "{{ secret('POSTGRES_PASSWORD_DEV') }}"
-      POSTGRES_USER: "{{ secret('POSTGRES_USER_DEV') }}"
+      POSTGRES_HOST: "{{ secret('POSTGRES_HOST') }}"
+      POSTGRES_PASSWORD: "{{ secret('POSTGRES_PASSWORD_READ') }}"
+      POSTGRES_USER: "{{ secret('POSTGRES_USER_READ') }}"
       SENTRY_DSN: "{{ secret('SENTRY_DSN') }}"
 
   - id: dbt_run_transformations
@@ -132,6 +135,7 @@ tasks:
       - -c
       - cd /app && /app/entrypoints/dbt.sh
     env:
+      DBT_ENV: dev
       DBT_PROFILES_DIR: /app/my_dbt_project/dbt
       DBT_PROJECT_DIR: /app/my_dbt_project
       LOGLEVEL: INFO
@@ -139,10 +143,11 @@ tasks:
       MODIN_ENGINE: python
       MODIN_MEMORY: 2000000000
       POSTGRES_DB: barometre
+      POSTGRES_PORT: 17975
       BUCKET: "{{ secret('SCW_ACCESS') }}"
       BUCKET_SECRET: "{{ secret('SCW_SECRET') }}"
-      LABELSTUDIO_INGESTION_POSTGRES_USER: "{{ secret('LABELSTUDIO_INGESTION_POSTGRES_USER') }}"
-      LABELSTUDIO_INGESTION_POSTGRES_PASSWORD: "{{ secret('LABELSTUDIO_INGESTION_POSTGRES_PASSWORD') }}"
+      LABELSTUDIO_INGESTION_POSTGRES_USER: "{{ secret('POSTGRES_USER_READ') }}"
+      LABELSTUDIO_INGESTION_POSTGRES_PASSWORD: "{{ secret('POSTGRES_PASSWORD_READ') }}"
       LABELSTUDIO_POSTGRES_HOST: "{{ secret('POSTGRES_HOST') }}"
       LABELSTUDIO_POSTGRES_PORT: 22737
       POSTGRES_USER: "{{ secret('POSTGRES_USER_DEV') }}"

--- a/infrastructure/live/barometre/dev/.terraform.lock.hcl
+++ b/infrastructure/live/barometre/dev/.terraform.lock.hcl
@@ -1,11 +1,60 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:7NpGFIxlybShI7Rp75FYsN1y634ERY8k2tWecAd+7E4=",
+    "h1:8BLHeBjRS/J2SB2jX/APsNqaCoW957ItWwYHB2tDJxQ=",
+    "h1:AjF6WvzpGqqqBL9GvRTnoNaBhb3gATNr7BQGKJZTgLg=",
+    "h1:Bxx62jDcZK0am+afGk6Ykai3xAJ+kywRBXKSFYurYVg=",
+    "h1:CQIlkT9lxTbVH4cxqXCx82pZKQEzOkLpT46RsxD/HYk=",
+    "h1:MZahRDJtGnhvg0wxOHDuaondAXVW2nXX5qpQyzP3VjM=",
+    "h1:R2VyKXqik22JkOOwhF9TRnizaP/xgbqa+1uWFlOF9Qk=",
+    "h1:TgathXtnDVLJSkETVDP6c9txmSsq5SJsud6O/28ptZg=",
+    "h1:UGqbICb3O/mPHa7dxJGYMdXEYfqFaWOBAlVwP+EkXsw=",
+    "h1:VVWIHk02wVfQjW0LZWebQcgPeEeiN9Vy2GNdHq5FExk=",
+    "h1:nXb/PVTFSacCYD6BQnTsgKPEUOGIVOgociSAE2iWN/c=",
+    "h1:sHruA5X0bMk1a9152XBk0E6F1TMsOwXcqMEIDm4dk4Y=",
+    "h1:sR5ZgoL7xEw1WrX2CMzwCShqojJpgDgoD5b7XR0rwyo=",
+    "h1:te8wkusyzI1LT1Aa08bB5oU5xgb1xp8oXMEZeLdFmg0=",
+    "h1:zlqgl4B3cEk+wNKcHTGuF1VrQTTmeWBSr1TqwnLuWLA=",
+    "zh:155688768de4c53bc6523c5fed46aa4a74c8fc8cab25ea808ce2ff24e2f5ae83",
+    "zh:1af6716fa8e7c4fd8be408ff2ff6ee12759171bb128d162f9926ad32cb0ffa49",
+    "zh:1be2795c86651fd1d87fffba6013086d56890ce6db1f541ae2ba9404db24d4a6",
+    "zh:2fb4a1dfaf37d452ce5981925215dd0e0f6c89733a3c97c8f78307a05765939a",
+    "zh:5986f66d98602017953257ef51bb6396d2bc648ebcaf8feb9c088b3585ff2195",
+    "zh:6047a3daafe8ce495aef249a128ba4002aca334b811bafddea521ebca03b11dc",
+    "zh:6e0be9e14223fe21bf38ba723026d2eee2dc1e5dfab6f7fc4d31bfa8c19a7543",
+    "zh:7d391e37de3043bc4aad2a51146154ac9a63022527524136880807cf8addc719",
+    "zh:7d9726369f062243ffc474068f56cb315911250f73e03fa3d63833293e092d1a",
+    "zh:905790b553654aa66db59d5efda57ae207f72ade11677983c0849a83f4f7969b",
+    "zh:a24165685313941779a0be04c36ddbc33836f26b8a5a9198eb01dbb1e339dda8",
+    "zh:a4228f0edd34868696077710200409936963ae93f3cf108bce3ec6b936e458b6",
+    "zh:b82a35e7b7ef55bc329a6dc084d19d034ff9cc9372d904f4134c6ec9cc3a1ca3",
+    "zh:c00432d129e4ddfa5e986aa872d442e918496c118a04b3b259b167ca40257575",
+    "zh:f804b662a4c82dfa241ae9ddc9cb35b7c197e7e97a578cef4dc425a4002eadf1",
+  ]
+}
+
 provider "registry.opentofu.org/scaleway/scaleway" {
   version     = "2.73.0"
   constraints = "~> 2.57"
   hashes = [
+    "h1:0zFHYEAw9+2wnFuO+rTb0I329aZZP1defqK17jUllH8=",
+    "h1:B+m2HPVnyQQZdlMSn4OVo18G86/FS080jw/tdc4il3M=",
+    "h1:BN8GI23K465wVvuHldavTMAjiOkLkHeAlRs/4rfF4a8=",
+    "h1:BPY28hzI9Dc8XGeK7XU9tu9CuSoi9YbxIZQKMh2O4+E=",
+    "h1:DLOtAimHskQYDUK9qIhiWyuJYeVtgRNPU8PvF8cBWUc=",
+    "h1:EoxWfwfPQ9oc/sbjALZb7uhbnDKr/kuYMj61Ulc6mGA=",
     "h1:OjdLX6A8rVgH6h8NE6KhnwGn2NflQaG7b4r9LKZKZjs=",
+    "h1:d0JlYFZvdatRR+XgrhZL1yCDbp+zUmz5+Txyew8IWjU=",
+    "h1:jdA/puCVV/wS6DfBuNejbPdS+x2/Y+eyOM6iXkOg/IA=",
+    "h1:jm9/4prEyD1iFt9z7EIS+DfuZQsg5RdOGtPfLankduk=",
+    "h1:ma9qO9CMrgTnGASZKY0CHIa+FlBGLtSyha8XLqkccxE=",
+    "h1:mf4RsNXz/xW78lIlV7GUqNxB6ttXonY4r5xALFaX4Bw=",
+    "h1:veg5TveGGivXijsTxAKqDPgbshVfnDSPA08CIUQz/hk=",
     "zh:1997c81d5dda1ac7b027404140c7473f6bc5d1c39b228a6f07da536f65935d41",
     "zh:3af28a4ae59eb013254143f2c49d60f8b479fbd6b61316d13ba191d6b22888f4",
     "zh:41f8dbb0614d4a5d15cc4d9ecc32abc1122345ebfe3b1e18962b1d5564f85e71",

--- a/infrastructure/live/barometre/template/database.tf
+++ b/infrastructure/live/barometre/template/database.tf
@@ -33,6 +33,20 @@ resource "scaleway_rdb_privilege" "barometre_admin" {
   permission    = "all"
 }
 
+resource "scaleway_rdb_user" "rrs_read" {
+  instance_id = scaleway_rdb_instance.barometre_rdb.id
+  name        = "rrs-read-${var.environment}"
+  password    = var.barometre_rrs_read_password
+  is_admin    = false
+}
+
+resource "scaleway_rdb_privilege" "rrs_read" {
+  instance_id   = scaleway_rdb_instance.barometre_rdb.id
+  user_name     = scaleway_rdb_user.rrs_read.name
+  database_name = scaleway_rdb_database.barometre.name
+  permission    = "readonly"
+}
+
 # Allow public access so the migration script can reach the instance.
 # Dev only — restrict to specific IPs in production.
 resource "scaleway_rdb_acl" "public" {

--- a/infrastructure/live/barometre/template/variables.tf
+++ b/infrastructure/live/barometre/template/variables.tf
@@ -12,6 +12,10 @@ variable "postgres_admin_password" {
   type      = string
   sensitive = true
 }
+variable "barometre_rrs_read_password" {
+  type      = string
+  sensitive = true
+}
 
 variable "postgres_admin_password_version" {
   type    = number


### PR DESCRIPTION
## Summary
Infrastructure-only changes for the dev environment.

- **Ansible**: fix SSH login by setting `remote_user: ubuntu` on the deploy
  playbook. Also wire through new env vars (`API_LABEL_STUDIO_KEY`,
  `API_LABEL_STUDIO_KEY_DEV`, and the RRS read-only Postgres creds).
- **Terraform**: provision a `readonly` Scaleway RDB user
  (`rrs-read-${environment}`) on the barometre database, with a new
  sensitive `barometre_rrs_read_password` variable. Update the dev
  `.terraform.lock.hcl`.
- **Kestra dev flow** (`main_quotaclimatdev_barometre.yaml`):
  - bump import task `shmSize` 2gb→10gb and `API_TO_S3_CONCURRENCY` 3→10
  - add `logLevel: WARN` to two tasks to stop per-row INFO logs freezing
    the Kestra UI
  - switch container-registry auth to `username: nologin` + password
  - point the label-misinformation task at read-only DB creds/host/port,
    set `DBT_ENV: dev`, and use the read user for labelstudio ingestion

## Test plan
- Terraform: `tofu plan` in `infrastructure/live/barometre/dev` shows only
  the new RDB user/privilege.
- Ansible: deploy run authenticates as `ubuntu` and the new env vars are
  present on the host.
- Kestra: dev flow runs without the UI freezing.
