### PR TITLE
Create a metabase proxy

### DIFF
--- a/.github/workflows/deploy-tools.yml
+++ b/.github/workflows/deploy-tools.yml
@@ -1,0 +1,36 @@
+name: Build & Deploy team tools to Scaleway
+
+on:
+  push:
+      # Sequence of patterns matched against refs/heads
+    branches:
+      - main
+    paths:
+      - 'metabase_proxy/**'
+
+  # to be able to force deploy
+  workflow_dispatch:
+
+
+env:
+  PYTHON_VERSION: '3.12'
+  POETRY_VERSION: '2.1.3'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Login to Scaleway Container Registry
+      uses: docker/login-action@v3
+      with:
+        username: nologin
+        password: ${{ secrets.SCALEWAY_API_KEY }}
+        registry: ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}
+
+    - name: Build metabase_proxy image
+      run: docker build -f metabase_proxy/Dockerfile metabase_proxy/ -t ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/metabase_proxy:${{ env.PROJECT_VERSION }}
+    - name: Tag metabase_proxy latest image
+      run: docker tag ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/metabase_proxy:${{ env.PROJECT_VERSION }} ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/metabase_proxy:latest
+    - name: Push metabase_proxy Image
+      run: docker push --all-tags ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/metabase_proxy

--- a/metabase_proxy/Dockerfile
+++ b/metabase_proxy/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/templates/default.conf.template

--- a/metabase_proxy/nginx.conf
+++ b/metabase_proxy/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 8080;
+
+    resolver 8.8.8.8 ipv6=off;
+
+    # In order for those var env to be replaced at run time, this file should be placed as an nginx template. See Dockerfile
+    location /${INTERCEPT_PATH}/ {
+        proxy_pass ${INTERCEPT_PROXY_PASS}/;
+    }
+    location / {
+        proxy_pass ${DEFAULT_PROXY_PASS};
+    }
+}


### PR DESCRIPTION
The goal is to be able to host some one-page-app in the same domain that our metabase in order to be able to reuse its authentication mecanism, and it's query features.

This proxy is just a nginx running in a function, that proxy pass to metabase.
It also intercept a user defined path, in order to root specific http calls to another target. This target is configured inside scaleway to be the public interface of a bucket, allowing us to expose any simple html page on the metabase domain