### PR TITLE
Replace browser-based Pulsar pipeline with API-key pipeline

### DIFF
--- a/infrastructure/ansible/playbook.yml
+++ b/infrastructure/ansible/playbook.yml
@@ -48,6 +48,7 @@
       POSTGRES_USER: "{{ lookup('env', 'BAROMETRE_POSTGRES_USER') }}"
       POSTGRES_PASSWORD_READ: "{{ lookup('env', 'BAROMETRE_POSTGRES_PASSWORD_READ') }}"
       POSTGRES_USER_READ: "{{ lookup('env', 'BAROMETRE_POSTGRES_USER_READ') }}"
+      PULSAR_API_KEY: "{{ lookup('env', 'PULSAR_API_KEY') }}"
       PULSAR_BASE_URL: "{{ lookup('env', 'PULSAR_BASE_URL') }}"
       PULSAR_EMAIL: "{{ lookup('env', 'PULSAR_EMAIL') }}"
       PULSAR_PASSWORD: "{{ lookup('env', 'PULSAR_PASSWORD') }}"

--- a/infrastructure/kestra/flows/main_quotaclimat_barometre.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimat_barometre.yaml
@@ -1,6 +1,17 @@
 id: barometre
 namespace: quotaclimat
 
+description: |
+  Main detection pipeline for the OME. Ingests data from Mediatree into S3, 
+  detects the presence of keywords using a validation methodology for high 
+  risk false positives, detects possible misinformation using an LLM and 
+  aggregates data using DBT.
+
+labels:
+  pipeline: ome
+  environment: prod
+  scope: france
+
 triggers:
   - id: morning_schedule
     type: io.kestra.plugin.core.trigger.Schedule

--- a/infrastructure/kestra/flows/main_quotaclimat_barometrecatchup.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimat_barometrecatchup.yaml
@@ -1,6 +1,15 @@
 id: barometre-catchup
 namespace: quotaclimat
 
+description: |
+  Catchup pipeline for the OME. Runs over the last week skipping days that 
+  have been analysed already.
+
+labels:
+  pipeline: ome
+  environment: prod
+  scope: france
+
 triggers:
   - id: daily_schedule
     type: io.kestra.plugin.core.trigger.Schedule

--- a/infrastructure/kestra/flows/main_quotaclimat_barometrei18n.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimat_barometrei18n.yaml
@@ -1,6 +1,15 @@
 id: barometre-i18n
 namespace: quotaclimat
 
+description: |
+  OME pipeline for international scope. The misinformation detection uses scaleway 
+  serverless jobs at the moment to run everything in parallel.
+
+labels:
+  pipeline: ome
+  environment: prod
+  scope: i18n
+
 triggers:
   - id: morning_schedule
     type: io.kestra.plugin.core.trigger.Schedule

--- a/infrastructure/kestra/flows/main_quotaclimatdev_barometre.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimatdev_barometre.yaml
@@ -1,6 +1,14 @@
 id: barometre
 namespace: quotaclimat-dev
 
+description: |
+  Dev pipeline for the main OME flow.
+
+labels:
+  pipeline: ome
+  environment: dev
+  scope: france
+
 tasks:
   - id: ingest_data_to_s3
     type: io.kestra.plugin.docker.Run

--- a/infrastructure/kestra/flows/main_rrs_climate.yaml
+++ b/infrastructure/kestra/flows/main_rrs_climate.yaml
@@ -1,6 +1,15 @@
 id: rrs-climate
 namespace: rrs
 
+description: |
+  Climate pipeline for RRS imports data from the OME database and performs clustering
+  for audiovisual data sourced from Mediatree.
+
+labels:
+  pipeline: rrs
+  environment: prod
+  scope: france
+
 inputs:
   - id: start_date
     type: STRING

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -63,7 +63,7 @@ tasks:
           PULSAR_BASE_URL: "{{ secret('PULSAR_BASE_URL') }}"
           PULSAR_EMAIL: "{{ secret('PULSAR_EMAIL') }}"
           PULSAR_PASSWORD: "{{ secret('PULSAR_PASSWORD') }}"
-          PULSAR_RELEVANCE_MENTION_TAG_IDS: "{{ json(inputs.relevance_mention_tag_ids) }}"
+          PULSAR_RELEVANCE_MENTION_TAG_IDS: "{{ inputs.relevance_mention_tag_ids }}"
           PULSAR_FOLDER_ID: "{{ json(taskrun.value).folder_id }}"
           PULSAR_SEARCH_ID: "{{ json(taskrun.value).search_id }}"
           PULSAR_TOP_N: "{{ inputs.n_top_posts }}"

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -66,6 +66,7 @@ tasks:
           PULSAR_RELEVANCE_MENTION_TAG_IDS: "{{ inputs.relevance_mention_tag_ids }}"
           PULSAR_FOLDER_ID: "{{ json(taskrun.value).folder_id }}"
           PULSAR_SEARCH_ID: "{{ json(taskrun.value).search_id }}"
+          SUBJECT: "{{ json(taskrun.value).subject }}"
           PULSAR_TOP_N: "{{ inputs.n_top_posts }}"
           PULSAR_DAYS_BACK: "{{ inputs.days_back }}"
           PULSAR_START_DATE: "{{ inputs.start_date ?? '' }}"

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -28,6 +28,14 @@ inputs:
   - id: n_top_posts
     type: INT
     defaults: 30
+  - id: start_date
+    type: STRING
+    required: false
+    description: "Start of the analysis window (YYYY-MM-DD). Overrides days_back when set."
+  - id: end_date
+    type: STRING
+    required: false
+    description: "End of the analysis window (YYYY-MM-DD). Defaults to now when not set."
 
 tasks:
   - id: per_search
@@ -57,6 +65,8 @@ tasks:
           PULSAR_SEARCH_ID: "{{ json(taskrun.value).search_id }}"
           PULSAR_TOP_N: "{{ inputs.n_top_posts }}"
           PULSAR_DAYS_BACK: "{{ inputs.days_back }}"
+          PULSAR_START_DATE: "{{ inputs.start_date }}"
+          PULSAR_END_DATE: "{{ inputs.end_date }}"
           RRS_PG_HOST: "{{ secret('RRS_PG_HOST_DEV') }}"
           RRS_PG_PORT: 18047
           RRS_PG_DATABASE: rrs

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -10,6 +10,8 @@ description: |
 
 labels:
   pipeline: rrs
+  environment: dev
+  scope: france
 
 inputs:
   # One entry per Pulsar search to pull. Add objects to scale to X instances.
@@ -17,7 +19,7 @@ inputs:
     type: JSON
     defaults: |
       [
-        {"name": "renewables", "folder_id": "529", "search_id": "201830", "subject": "climate"}
+        {"name": "renewables", "folder_id": "529", "search_id": "201823", "subject": "climate"}
       ]
     description: "JSON string defining the details of the searches from which to extract the themes."
   - id: relevance_mention_tag_ids

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -19,6 +19,15 @@ inputs:
       [
         {"name": "renewables", "folder_id": "529", "search_id": "201830"}
       ]
+  - id: relevance_mention_tag_ids
+    type: JSON
+    defaults: "[]"
+  - id: days_back
+    type: INT
+    defaults: 1
+  - id: n_top_posts
+    type: INT
+    defaults: 30
 
 tasks:
   - id: per_search
@@ -36,16 +45,18 @@ tasks:
         commands:
           - python
           - -m
-          - rrs.pulsar.run
+          - rrs.pulsar.fetch_weekly_themes_client
         env:
           PYTHONPATH: /app
+          PULSAR_API_KEY: "{{ secret('PULSAR_API_KEY') }}"
           PULSAR_BASE_URL: "{{ secret('PULSAR_BASE_URL') }}"
           PULSAR_EMAIL: "{{ secret('PULSAR_EMAIL') }}"
           PULSAR_PASSWORD: "{{ secret('PULSAR_PASSWORD') }}"
+          PULSAR_RELEVANCE_MENTION_TAG_IDS: "{{ json(inputs.relevance_mention_tag_ids) }}"
           PULSAR_FOLDER_ID: "{{ json(taskrun.value).folder_id }}"
           PULSAR_SEARCH_ID: "{{ json(taskrun.value).search_id }}"
-          PULSAR_TOP_N: "30"
-          PULSAR_THEMES_OUTPUT: "themes.xlsx"
+          PULSAR_TOP_N: "{{ inputs.n_top_posts }}"
+          PULSAR_DAYS_BACK: "{{ inputs.days_back }}"
           RRS_PG_HOST: "{{ secret('RRS_PG_HOST_DEV') }}"
           RRS_PG_PORT: 18047
           RRS_PG_DATABASE: rrs

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -17,17 +17,20 @@ inputs:
     type: JSON
     defaults: |
       [
-        {"name": "renewables", "folder_id": "529", "search_id": "201830"}
+        {"name": "renewables", "folder_id": "529", "search_id": "201830", "subject": "climate"}
       ]
+    description: "JSON string defining the details of the searches from which to extract the themes."
   - id: relevance_mention_tag_ids
     type: JSON
     defaults: "[]"
   - id: days_back
     type: INT
     defaults: 1
+    description: "Look-back window in days"
   - id: n_top_posts
     type: INT
     defaults: 30
+    description: "Top posts to fetch per theme"
   - id: start_date
     type: STRING
     required: false

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -65,8 +65,8 @@ tasks:
           PULSAR_SEARCH_ID: "{{ json(taskrun.value).search_id }}"
           PULSAR_TOP_N: "{{ inputs.n_top_posts }}"
           PULSAR_DAYS_BACK: "{{ inputs.days_back }}"
-          PULSAR_START_DATE: "{{ inputs.start_date }}"
-          PULSAR_END_DATE: "{{ inputs.end_date }}"
+          PULSAR_START_DATE: "{{ inputs.start_date ?? '' }}"
+          PULSAR_END_DATE: "{{ inputs.end_date ?? '' }}"
           RRS_PG_HOST: "{{ secret('RRS_PG_HOST_DEV') }}"
           RRS_PG_PORT: 18047
           RRS_PG_DATABASE: rrs

--- a/poetry.lock
+++ b/poetry.lock
@@ -1905,7 +1905,7 @@ version = "2.0.0"
 description = "An implementation of lxml.xmlfile for the standard library"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
     {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
@@ -4695,7 +4695,7 @@ version = "3.1.5"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
@@ -9545,4 +9545,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "fabec5a2c620818f8d18bd06c34a49deab19bd9b3c4620c320ecd352c67a8624"
+content-hash = "dc2e3877f0e082f58534589a725872f1d958ee1fc8c53a9263093491610ef341"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1905,7 +1905,7 @@ version = "2.0.0"
 description = "An implementation of lxml.xmlfile for the standard library"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "pulsar", "rrs"]
+groups = ["main", "rrs"]
 files = [
     {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
     {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
@@ -2474,7 +2474,8 @@ version = "3.2.3"
 description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "pulsar"]
+groups = ["main"]
+markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
 files = [
     {file = "greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be"},
     {file = "greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac"},
@@ -2531,7 +2532,6 @@ files = [
     {file = "greenlet-3.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:aaa7aae1e7f75eaa3ae400ad98f8644bb81e1dc6ba47ce8a93d3f17274e08322"},
     {file = "greenlet-3.2.3.tar.gz", hash = "sha256:8b0dd8ae4c0d6f5e54ee55ba935eeb3d735a9b58a8a1e5b5cbab64e01a39f365"},
 ]
-markers = {main = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
 
 [package.extras]
 docs = ["Sphinx", "furo"]
@@ -4695,7 +4695,7 @@ version = "3.1.5"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "pulsar", "rrs"]
+groups = ["main", "rrs"]
 files = [
     {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
@@ -5218,28 +5218,6 @@ files = [
 docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
 type = ["mypy (>=1.14.1)"]
-
-[[package]]
-name = "playwright"
-version = "1.60.0"
-description = "A high-level API to automate web browsers"
-optional = false
-python-versions = ">=3.9"
-groups = ["pulsar"]
-files = [
-    {file = "playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7"},
-    {file = "playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5"},
-    {file = "playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705"},
-    {file = "playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e"},
-    {file = "playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353"},
-    {file = "playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7"},
-    {file = "playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02"},
-    {file = "playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537"},
-]
-
-[package.dependencies]
-greenlet = ">=3.1.1,<4.0.0"
-pyee = ">=13,<14"
 
 [[package]]
 name = "plotly"
@@ -6173,24 +6151,6 @@ files = [
 
 [package.extras]
 dev = ["tox"]
-
-[[package]]
-name = "pyee"
-version = "13.0.1"
-description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
-optional = false
-python-versions = ">=3.8"
-groups = ["pulsar"]
-files = [
-    {file = "pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"},
-    {file = "pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8"},
-]
-
-[package.dependencies]
-typing-extensions = "*"
-
-[package.extras]
-dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
 
 [[package]]
 name = "pyflakes"
@@ -8944,6 +8904,7 @@ files = [
     {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
     {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
 ]
+markers = {pulsar = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -9584,4 +9545,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "427ef9366bcddd8db1d134f4569900c1b672bc369811a42e70db226ee7309688"
+content-hash = "fabec5a2c620818f8d18bd06c34a49deab19bd9b3c4620c320ecd352c67a8624"

--- a/poetry.lock
+++ b/poetry.lock
@@ -515,7 +515,7 @@ version = "4.13.4"
 description = "Screen-scraping library"
 optional = false
 python-versions = ">=3.7.0"
-groups = ["main"]
+groups = ["main", "pulsar"]
 files = [
     {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
     {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
@@ -1665,6 +1665,27 @@ files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
 ]
+
+[[package]]
+name = "deep-translator"
+version = "1.11.4"
+description = "A flexible free and unlimited python tool to translate between different languages in a simple way using multiple translators"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["pulsar"]
+files = [
+    {file = "deep_translator-1.11.4-py3-none-any.whl", hash = "sha256:d635df037e23fa35d12fd42dab72a0b55c9dd19e6292009ee7207e3f30b9e60a"},
+    {file = "deep_translator-1.11.4.tar.gz", hash = "sha256:801260c69231138707ea88a0955e484db7d40e210c9e0ae0f77372ffda5f4bf5"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.9.1,<5.0.0"
+requests = ">=2.23.0,<3.0.0"
+
+[package.extras]
+ai = ["openai (>=0.27.6,<0.28.0) ; python_full_version >= \"3.7.1\" and python_full_version < \"4.0.0\""]
+docx = ["docx2txt (>=0.8,<0.9)"]
+pdf = ["pypdf (>=3.3.0,<4.0.0)"]
 
 [[package]]
 name = "deepdiff"
@@ -7912,7 +7933,7 @@ version = "2.7"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "pulsar"]
 files = [
     {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
     {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
@@ -8904,7 +8925,6 @@ files = [
     {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
     {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
 ]
-markers = {pulsar = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -9545,4 +9565,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "dc2e3877f0e082f58534589a725872f1d958ee1fc8c53a9263093491610ef341"
+content-hash = "9689bdc65bf19ba1a9710c0555b4b9c1bf2b4fb4483351ea17ca9c6c3e1f8de4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ requests = "^2.32.3"
 tenacity = "^8.2.3"
 python-dotenv = ">=1.0"
 tzdata = "^2026.2"
+deep-translator = "^1.11"
 openpyxl = "^3.1.5"
 
 [tool.pytest_env]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ requests = "^2.32.3"
 tenacity = "^8.2.3"
 python-dotenv = ">=1.0"
 tzdata = "^2026.2"
+openpyxl = "^3.1.5"
 
 [tool.pytest_env]
 CLEAN_CACHE_ON_EXIT=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,15 +106,12 @@ sentence-transformers = ">=3.0"
 sentencepiece = ">=0.2"
 openpyxl = ">=3.1"
 
-# Pulsar themes downloader only — Playwright/Chromium is heavy, so it is isolated
-# in its own optional group and its own (lean) image, kept out of rrs-base.
-# Pin must match the Playwright base image tag in rrs/Dockerfile.pulsar.
+# Pulsar themes pipeline — API-key-based, no browser automation.
+# Kept as a separate optional group so it doesn't bloat rrs-base.
 [tool.poetry.group.pulsar]
 optional = true
 
 [tool.poetry.group.pulsar.dependencies]
-playwright = "1.60.0"
-openpyxl = ">=3.1"
 psycopg = {version = ">=3.0", extras = ["binary"]}
 requests = "^2.32.3"
 tenacity = "^8.2.3"

--- a/rrs/Dockerfile.pulsar
+++ b/rrs/Dockerfile.pulsar
@@ -1,12 +1,9 @@
-# Lean image for the whole Pulsar pipeline (rrs.pulsar.run): download themes XLS +
-# capture token (Playwright) → parse → store + fetch posts (GraphQL).
+# Lean image for the Pulsar pipeline (rrs.pulsar.fetch_weekly_themes_client):
+# fetch themes via GraphQL API → store themes/topics → fetch + store top posts.
 #
-# Playwright + Chromium are heavy and used ONLY for this scrape, so they live in
-# this dedicated image instead of bloating rrs-base (which every other rrs job
-# pulls). The official Playwright base image ships Chromium + all OS deps + the
-# matching playwright python package; we add only the light deps the pipeline needs
-# (no ML stack). The tag MUST match the playwright pin in pyproject group "pulsar".
-FROM mcr.microsoft.com/playwright/python:v1.60.0-noble
+# No browser automation needed — the pipeline uses a permanent API key directly,
+# so the heavy Playwright/Chromium base image is replaced with a standard slim image.
+FROM python:3.12-slim
 
 WORKDIR /app
 ENV PYTHONPATH=/app
@@ -17,4 +14,4 @@ RUN pip install --no-cache-dir poetry \
     && poetry install --only pulsar --no-root --no-interaction
 COPY rrs/ ./rrs/
 
-CMD ["python", "-m", "rrs.pulsar.run"]
+CMD ["python", "-m", "rrs.pulsar.fetch_weekly_themes_client"]

--- a/rrs/alembic/versions/e1f2a3b4c5d6_add_subject_id_to_pulsar_tables.py
+++ b/rrs/alembic/versions/e1f2a3b4c5d6_add_subject_id_to_pulsar_tables.py
@@ -1,0 +1,32 @@
+"""add subject_id to pulsar tables
+
+Revision ID: e1f2a3b4c5d6
+Revises: a7c3f1e9b2d4
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "a7c3f1e9b2d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pulsar_searches",
+        sa.Column("subject_id", sa.String(), sa.ForeignKey("subjects.subject_id"), nullable=True),
+    )
+    op.add_column(
+        "pulsar_themes",
+        sa.Column("subject_id", sa.String(), sa.ForeignKey("subjects.subject_id"), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pulsar_themes", "subject_id")
+    op.drop_column("pulsar_searches", "subject_id")

--- a/rrs/alembic/versions/e1f2a3b4c5d6_add_subject_id_to_pulsar_tables.py
+++ b/rrs/alembic/versions/e1f2a3b4c5d6_add_subject_id_to_pulsar_tables.py
@@ -1,7 +1,7 @@
 """add subject_id to pulsar tables
 
 Revision ID: e1f2a3b4c5d6
-Revises: a7c3f1e9b2d4
+Revises: f32e36816995
 Create Date: 2026-07-06 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "e1f2a3b4c5d6"
-down_revision: Union[str, None] = "a7c3f1e9b2d4"
+down_revision: Union[str, None] = "f32e36816995"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -237,8 +237,8 @@ def run() -> None:
 
     headers = _make_headers(s.api_key)
     now = datetime.now(timezone.utc)
-    date_to_dt = now
-    date_from_dt = now - timedelta(days=s.days_back)
+    date_to_dt = s.end_date or now
+    date_from_dt = s.start_date or (date_to_dt - timedelta(days=s.days_back))
     date_to_str = date_to_dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
     date_from_str = date_from_dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -1,0 +1,277 @@
+"""
+Reproduce Pulsar's "What's the story?" / Themes tab via the API, on a weekly
+schedule. For a given search, this:
+
+  1. Calls `topics` to get the top curated NLP topics (e.g. "canicule",
+     "climatisation") with their exact post-count volumes, plus each
+     topic's co-occurring topics (via the nested `topics` field).
+  2. Greedily groups topics into theme clusters using co-occurrence: each
+     unassigned top topic seeds a theme, pulling in its strongest
+     co-occurring topics that haven't been claimed by an earlier theme.
+  3. Sums the member topics' volumes for the theme's post count — verified
+     against a real platform export (themes (3).xlsx) that this is exactly
+     how the platform computes "Volume of Posts" per theme.
+  4. Calls `summary` to pull representative posts for the theme's topics.
+  5. Feeds those posts into `narrativesSummarization` to generate the same
+     AI title / sentiment / body you see on each theme card in the UI.
+  6. Stores themes + topics in the database and fetches + stores the top
+     posts per theme via the Pulsar GraphQL data endpoint.
+
+ACCURACY NOTE: post-count volumes match the platform closely (validated
+against a real export — e.g. "canicule" 158,808 in the export vs 158,833
+live, drift is just from new content landing between the export and the
+live call). Which topics get grouped into the same theme is a best-effort
+greedy approximation of Pulsar's internal clustering, not a guaranteed
+match — the platform likely uses a proper community-detection algorithm
+over topic co-occurrence, and our theme *boundaries* won't always line up
+1:1 with the UI, even though individual topic counts do.
+
+This replaces an earlier version of this script that used `clustersOverTime`
+(raw keyword co-occurrence graph). That endpoint has a hard ~60s server-side
+timeout and could not complete even a single day's window on a large/dense
+search (we tested one with ~488k posts/week) no matter how it was tuned.
+`topics` has no such problem — it returned in ~20s on that same search.
+
+CONFIG (environment variables):
+
+  PULSAR_API_KEY                Permanent Pulsar API key (required).
+  PULSAR_SEARCH_ID              The search to pull themes for (required).
+  PULSAR_DAYS_BACK              Look-back window in days (default: 7).
+  PULSAR_TOP_N                  Top posts to fetch per theme (default: 30).
+  PULSAR_RELEVANCE_MENTION_TAG_IDS
+                                JSON array of tag IDs for the search's custom
+                                relevance module, e.g. '["tag_id_1"]'.
+                                Leave unset or '[]' if not needed.
+
+                                To find it: open the search in the Pulsar UI >
+                                Analysis > Relevancy, click "<Module>: Relevant",
+                                Apply. Then in browser DevTools > Network
+                                (filter "graphql"), find the request with
+                                operationName "Results" and look at
+                                variables.filter.mentionTags.
+
+  PULSAR_EMAIL / PULSAR_PASSWORD / PULSAR_FOLDER_ID
+                                Required by PulsarSettings.from_env() but not
+                                used by this pipeline; set to dummy values if
+                                running this script standalone.
+"""
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+from rrs.pulsar import store
+from rrs.pulsar.parse_themes import Theme, Topic
+from rrs.pulsar.posts_client import PulsarPostsClient
+from rrs.pulsar.settings import PulsarSettings
+
+DATA_ENDPOINT = "https://data.pulsarplatform.com/graphql/trac"
+APP_ENDPOINT  = "https://trac.pulsarplatform.com/graphql"
+
+TOPIC_UNIVERSE_SIZE = 30   # how many top topics to consider at all
+MAX_TOPICS_PER_THEME = 3   # cap on how many topics get grouped into one theme
+MAX_THEMES = 10            # how many top themes to turn into cards (platform UI caps at 10)
+MAX_SENTENCES = 10         # posts fed into the AI summary per theme
+OUT_JSON = "themes_{date}.json"
+
+# `stat.type` is a required enum but appears to have no effect when
+# `stat.metric` is COUNT (verified: value matched the platform's post count
+# regardless of which StatEnum value was used here) — any valid value works.
+STAT_TYPE = "VISIBILITY"
+
+TOPICS_QUERY = """
+query Topics($filter: FilterInput!, $options: OptionsInput, $stat: StatInput) {
+  topics(filter: $filter, options: $options, stat: $stat) {
+    label
+    value
+    topics {
+      label
+      value
+    }
+  }
+}
+"""
+
+SUMMARY_QUERY = """
+query Summary($options: OptionsInput, $filter: FilterInput!, $segment: [String!]!, $field: SummaryFieldEnum, $maxSentences: Int, $maxTitles: Int) {
+  summary(filter: $filter, options: $options, segment: $segment, field: $field, maxSentences: $maxSentences, maxTitles: $maxTitles) {
+    relevantTitles
+    relevantSentences
+  }
+}
+"""
+
+NARRATIVE_QUERY = """
+query NarrativesSummarization($contents: [String!]!) {
+  narrativesSummarization(contents: $contents) {
+    title
+    sentiment
+    body
+  }
+}
+"""
+
+
+def _make_headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+
+def _post(endpoint: str, query: str, variables: dict, headers: dict, retries: int = 4) -> dict:
+    last_resp = None
+    for attempt in range(retries):
+        resp = requests.post(endpoint, headers=headers,
+                              json={"query": query, "variables": variables}, timeout=90)
+        if resp.status_code == 200:
+            payload = resp.json()
+            if "errors" in payload:
+                raise RuntimeError(payload["errors"])
+            return payload
+        wait = 5 * (attempt + 1)
+        print(f"    got {resp.status_code}, retrying in {wait}s (attempt {attempt + 1}/{retries})...")
+        last_resp = resp
+        time.sleep(wait)
+    last_resp.raise_for_status()
+
+
+def _build_filter(search_id: str, date_from_str: str, date_to_str: str,
+                  relevance_mention_tag_ids: list) -> dict:
+    return {
+        "searchIds": [search_id],
+        "dateFrom": date_from_str,
+        "dateTo": date_to_str,
+        "mentionTags": relevance_mention_tag_ids,
+    }
+
+
+def get_top_themes(search_id: str, date_from_str: str, date_to_str: str,
+                   relevance_mention_tag_ids: list, headers: dict) -> list[dict]:
+    """Return up to MAX_THEMES theme dicts, each with topics (label+volume) and total volume."""
+    payload = _post(DATA_ENDPOINT, TOPICS_QUERY, {
+        "filter": _build_filter(search_id, date_from_str, date_to_str, relevance_mention_tag_ids),
+        "options": {"limit": TOPIC_UNIVERSE_SIZE},
+        "stat": {"type": STAT_TYPE, "metric": "COUNT"},
+    }, headers)
+    topics = payload["data"]["topics"]
+    volume_lookup = {t["label"]: t["value"] for t in topics}
+
+    assigned = set()
+    themes = []
+    for seed in sorted(topics, key=lambda t: -t["value"]):
+        if seed["label"] in assigned:
+            continue
+        members = [seed["label"]]
+        assigned.add(seed["label"])
+
+        cooccurring = sorted(seed["topics"], key=lambda t: -t["value"])
+        for co in cooccurring:
+            if len(members) >= MAX_TOPICS_PER_THEME:
+                break
+            if co["label"] in assigned or co["label"] not in volume_lookup:
+                continue
+            members.append(co["label"])
+            assigned.add(co["label"])
+
+        themes.append({
+            "topics": [{"label": m, "volume": volume_lookup[m]} for m in members],
+            "volume": sum(volume_lookup[m] for m in members),
+        })
+
+    ranked = sorted(themes, key=lambda t: -t["volume"])
+    return ranked[:MAX_THEMES]
+
+
+def build_theme(candidate: dict, search_id: str, date_from_str: str, date_to_str: str,
+                relevance_mention_tag_ids: list, headers: dict) -> dict | None:
+    """Enrich a candidate theme with AI title/sentiment/body via Pulsar API."""
+    topic_labels = [t["label"] for t in candidate["topics"]]
+    sresp = _post(DATA_ENDPOINT, SUMMARY_QUERY, {
+        "filter": _build_filter(search_id, date_from_str, date_to_str, relevance_mention_tag_ids),
+        "options": {},
+        "segment": topic_labels,
+        "field": "TOPICS",
+        "maxSentences": MAX_SENTENCES,
+        "maxTitles": MAX_SENTENCES,
+    }, headers)
+    sentences = sresp["data"]["summary"]["relevantSentences"]
+    if not sentences:
+        return None
+
+    nresp = _post(APP_ENDPOINT, NARRATIVE_QUERY, {"contents": sentences}, headers)
+    n = nresp["data"]["narrativesSummarization"]
+
+    return {
+        "topics": candidate["topics"],
+        "post_volume": candidate["volume"],
+        "title": n["title"],
+        "sentiment": n["sentiment"],
+        "body": n["body"],
+        "example_posts": sentences,
+    }
+
+
+def run() -> None:
+    s = PulsarSettings.from_env()
+    if not s.api_key:
+        raise EnvironmentError("PULSAR_API_KEY is required for the weekly themes API pipeline.")
+
+    headers = _make_headers(s.api_key)
+    now = datetime.now(timezone.utc)
+    date_to_dt = now
+    date_from_dt = now - timedelta(days=s.days_back)
+    date_to_str = date_to_dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    date_from_str = date_from_dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    print(f"Search: {s.search_id}")
+    print(f"Window: {date_from_str} to {date_to_str}")
+
+    candidates = get_top_themes(
+        s.search_id, date_from_str, date_to_str, s.relevance_mention_tag_ids, headers
+    )
+    print(f"Found {len(candidates)} candidate themes\n")
+
+    enriched = []
+    for candidate in candidates:
+        theme_data = build_theme(
+            candidate, s.search_id, date_from_str, date_to_str, s.relevance_mention_tag_ids, headers
+        )
+        if theme_data is None:
+            print(f"  {[t['label'] for t in candidate['topics']]}: no representative posts, skipped")
+            continue
+        enriched.append(theme_data)
+        print(f"  [{theme_data['sentiment']}] {theme_data['title']} ({theme_data['post_volume']:,} posts)")
+        time.sleep(0.5)
+
+    out_file = OUT_JSON.format(date=datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    with open(out_file, "w") as f:
+        json.dump(enriched, f, indent=2)
+    print(f"\nSaved {len(enriched)} themes to {out_file}")
+
+    posts_client = PulsarPostsClient.from_api_key(s.api_key)
+    total_posts = 0
+
+    with store.connect() as conn:
+        store.upsert_search(conn, s.search_id, name=s.search_id, folder_id="", base_url="")
+        for theme_data in enriched:
+            theme = Theme(
+                title=theme_data["title"],
+                summary=theme_data["body"],
+                volume=theme_data["post_volume"],
+                sentiment=theme_data["sentiment"],
+                topics=[Topic(label=t["label"], volume=t["volume"]) for t in theme_data["topics"]],
+            )
+            theme_id = store.insert_theme(conn, s.search_id, theme, date_from_dt, date_to_dt)
+
+            topic_labels = [t["label"] for t in theme_data["topics"]]
+            posts = posts_client.fetch_theme_posts(
+                s.search_id, topic_labels, date_from_dt, date_to_dt, limit=s.top_n
+            )
+            total_posts += store.upsert_posts(conn, s.search_id, theme_id, posts)
+        conn.commit()
+
+    print(f"Stored {len(enriched)} theme(s) and {total_posts} post(s) for search {s.search_id}.")
+
+
+if __name__ == "__main__":
+    run()

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -61,6 +61,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 import requests
+from deep_translator import GoogleTranslator
 
 from rrs.pulsar import store
 from rrs.pulsar.parse_themes import Theme, Topic
@@ -80,6 +81,24 @@ OUT_JSON = "themes_{date}.json"
 # `stat.metric` is COUNT (verified: value matched the platform's post count
 # regardless of which StatEnum value was used here) — any valid value works.
 STAT_TYPE = "VISIBILITY"
+
+_SENTIMENT_FR = {
+    "positive": "positif",
+    "negative": "négatif",
+    "neutral": "neutre",
+    "mixed": "mixte",
+}
+
+
+def _translate_to_french(title: str, body: str) -> tuple[str, str]:
+    """Translate title and body to French in a single batch call."""
+    texts = [t for t in (title, body) if t]
+    if not texts:
+        return title, body
+    translated = GoogleTranslator(source="auto", target="fr").translate_batch(texts)
+    it = iter(translated)
+    return (next(it) if title else title), (next(it) if body else body)
+
 
 TOPICS_QUERY = """
 query Topics($filter: FilterInput!, $options: OptionsInput, $stat: StatInput) {
@@ -242,6 +261,14 @@ def run() -> None:
         enriched.append(theme_data)
         print(f"  [{theme_data['sentiment']}] {theme_data['title']} ({theme_data['post_volume']:,} posts)")
         time.sleep(0.5)
+
+    print(f"\nTranslating {len(enriched)} theme(s) to French...")
+    all_texts = [t for theme in enriched for t in (theme["title"], theme["body"])]
+    translated = GoogleTranslator(source="auto", target="fr").translate_batch(all_texts)
+    for i, theme in enumerate(enriched):
+        theme["title"] = translated[i * 2]
+        theme["body"] = translated[i * 2 + 1]
+        theme["sentiment"] = _SENTIMENT_FR.get((theme["sentiment"] or "").lower(), theme["sentiment"])
 
     out_file = OUT_JSON.format(date=datetime.now(timezone.utc).strftime("%Y-%m-%d"))
     with open(out_file, "w") as f:

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -279,7 +279,8 @@ def run() -> None:
     total_posts = 0
 
     with store.connect() as conn:
-        store.upsert_search(conn, s.search_id, name=s.search_id, folder_id="", base_url="")
+        store.upsert_search(conn, s.search_id, name=s.search_id, folder_id="", base_url="",
+                            subject_id=s.subject_id)
         for theme_data in enriched:
             theme = Theme(
                 title=theme_data["title"],
@@ -288,7 +289,8 @@ def run() -> None:
                 sentiment=theme_data["sentiment"],
                 topics=[Topic(label=t["label"], volume=t["volume"]) for t in theme_data["topics"]],
             )
-            theme_id = store.insert_theme(conn, s.search_id, theme, date_from_dt, date_to_dt)
+            theme_id = store.insert_theme(conn, s.search_id, theme, date_from_dt, date_to_dt,
+                                          subject_id=s.subject_id)
 
             topic_labels = [t["label"] for t in theme_data["topics"]]
             posts = posts_client.fetch_theme_posts(

--- a/rrs/pulsar/posts_client.py
+++ b/rrs/pulsar/posts_client.py
@@ -112,6 +112,6 @@ class PulsarPostsClient:
         filter_ = {**_BASE_FILTER, "searchIds": [search_id], "topics": topics,
                    "dateFrom": _iso(date_from), "dateTo": _iso(date_to)}
         options = {"limit": limit, "sort": "DESC", "sortBy": "VISIBILITY", "cursor": "*",
-                   "forceCacheRefresh": True, "engine": "SOLR"}
+                   "forceCacheRefresh": True}
         data = self._post({"filter": filter_, "options": options})
         return (data.get("topContent") or {}).get("results") or []

--- a/rrs/pulsar/posts_client.py
+++ b/rrs/pulsar/posts_client.py
@@ -69,14 +69,18 @@ def _iso(dt: datetime | None) -> str | None:
 
 
 class PulsarPostsClient:
-    def __init__(self, authorization: str, team: str):
-        # `authorization` is the verbatim header value captured from the session (e.g. "Bearer eyJ…").
-        self._headers = {
-            "authorization": authorization,
-            "x-pulsar-team": team,
-            "content-type": "application/json",
-        }
+    def __init__(self, authorization: str, team: str | None = None):
+        # `authorization` is the verbatim header value (e.g. "Bearer eyJ…").
+        # `team` is the x-pulsar-team header, required for session tokens but not for API keys.
+        self._headers = {"authorization": authorization, "content-type": "application/json"}
+        if team:
+            self._headers["x-pulsar-team"] = team
         self._last_request_at = 0.0
+
+    @classmethod
+    def from_api_key(cls, api_key: str) -> "PulsarPostsClient":
+        """Create a client authenticated with a permanent Pulsar API key."""
+        return cls(authorization=f"Bearer {api_key}")
 
     def _throttle(self) -> None:
         elapsed = time.monotonic() - self._last_request_at

--- a/rrs/pulsar/run.py
+++ b/rrs/pulsar/run.py
@@ -1,4 +1,6 @@
-"""Pulsar pipeline (one search): download themes XLS + capture session token →
+"""
+DEPRECATED
+Pulsar pipeline (one search): download themes XLS + capture session token →
 parse (themes + topics) → store into pulsar_* tables → fetch each theme's top posts
 via GraphQL → store posts.
 

--- a/rrs/pulsar/settings.py
+++ b/rrs/pulsar/settings.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 
 from dotenv import load_dotenv
 
+from rrs.utils.generate_id import get_consistent_hash
+
 DEFAULT_BASE_URL = "https://lessurligneurs.pulsarplatform.com"
 
 
@@ -27,6 +29,7 @@ class PulsarSettings:
     api_key: str | None = None
     relevance_mention_tag_ids: list[str] = field(default_factory=list)
     days_back: int = 7
+    subject_id: str | None = None
 
     @classmethod
     def from_env(cls) -> "PulsarSettings":
@@ -67,4 +70,5 @@ class PulsarSettings:
             api_key=os.getenv("PULSAR_API_KEY"),
             relevance_mention_tag_ids=relevance_mention_tag_ids,
             days_back=int(os.getenv("PULSAR_DAYS_BACK", "7")),
+            subject_id=get_consistent_hash(subject) if (subject := os.getenv("SUBJECT")) else None,
         )

--- a/rrs/pulsar/settings.py
+++ b/rrs/pulsar/settings.py
@@ -7,10 +7,17 @@ runs in the lean image, so no embedding/LLM config here.
 import json
 import os
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 from dotenv import load_dotenv
 
 from rrs.utils.generate_id import get_consistent_hash
+
+_DATE_FMT = "%Y-%m-%d"
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.strptime(value, _DATE_FMT).replace(tzinfo=timezone.utc)
 
 DEFAULT_BASE_URL = "https://lessurligneurs.pulsarplatform.com"
 
@@ -30,6 +37,8 @@ class PulsarSettings:
     relevance_mention_tag_ids: list[str] = field(default_factory=list)
     days_back: int = 7
     subject_id: str | None = None
+    start_date: datetime | None = None  # explicit window start; falls back to days_back if unset
+    end_date: datetime | None = None    # explicit window end; falls back to now() if unset
 
     @classmethod
     def from_env(cls) -> "PulsarSettings":
@@ -71,4 +80,6 @@ class PulsarSettings:
             relevance_mention_tag_ids=relevance_mention_tag_ids,
             days_back=int(os.getenv("PULSAR_DAYS_BACK", "7")),
             subject_id=get_consistent_hash(subject) if (subject := os.getenv("SUBJECT")) else None,
+            start_date=_parse_date(v) if (v := os.getenv("PULSAR_START_DATE")) else None,
+            end_date=_parse_date(v) if (v := os.getenv("PULSAR_END_DATE")) else None,
         )

--- a/rrs/pulsar/settings.py
+++ b/rrs/pulsar/settings.py
@@ -4,8 +4,9 @@ Light by design — the whole pipeline (download → parse → store → fetch p
 runs in the lean image, so no embedding/LLM config here.
 """
 
+import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from dotenv import load_dotenv
 
@@ -22,6 +23,10 @@ class PulsarSettings:
     themes_xlsx: str = "pulsar_themes.xlsx"
     top_n: int = 30
     headless: bool = True
+    # API-key-based pipeline (fetch_weekly_themes_client)
+    api_key: str | None = None
+    relevance_mention_tag_ids: list[str] = field(default_factory=list)
+    days_back: int = 7
 
     @classmethod
     def from_env(cls) -> "PulsarSettings":
@@ -45,6 +50,11 @@ class PulsarSettings:
                 f"Missing Pulsar config: {', '.join(missing)}. "
                 "Set them in your environment (1Password locally; Vaultwarden→Kestra secret in prod)."
             )
+        raw_tag_ids = os.getenv("PULSAR_RELEVANCE_MENTION_TAG_IDS", "[]")
+        try:
+            relevance_mention_tag_ids = json.loads(raw_tag_ids)
+        except json.JSONDecodeError:
+            relevance_mention_tag_ids = []
         return cls(
             email=email,
             password=password,
@@ -54,4 +64,7 @@ class PulsarSettings:
             themes_xlsx=os.getenv("PULSAR_THEMES_OUTPUT", f"pulsar_themes_{search_id}.xlsx"),
             top_n=int(os.getenv("PULSAR_TOP_N", "30")),
             headless=os.getenv("PULSAR_HEADLESS", "true").lower() not in ("0", "false", "no"),
+            api_key=os.getenv("PULSAR_API_KEY"),
+            relevance_mention_tag_ids=relevance_mention_tag_ids,
+            days_back=int(os.getenv("PULSAR_DAYS_BACK", "7")),
         )

--- a/rrs/pulsar/store.py
+++ b/rrs/pulsar/store.py
@@ -24,31 +24,34 @@ def _conninfo() -> str:
     )
 
 
-def upsert_search(conn, search_id: str, name: str, folder_id: str, base_url: str) -> None:
+def upsert_search(conn, search_id: str, name: str, folder_id: str, base_url: str,
+                  subject_id: str | None = None) -> None:
     conn.execute(
         """
-        INSERT INTO pulsar_searches (search_id, name, folder_id, base_url, updated_at)
-        VALUES (%s, %s, %s, %s, now())
+        INSERT INTO pulsar_searches (search_id, subject_id, name, folder_id, base_url, updated_at)
+        VALUES (%s, %s, %s, %s, %s, now())
         ON CONFLICT (search_id) DO UPDATE
-            SET name = EXCLUDED.name, folder_id = EXCLUDED.folder_id,
-                base_url = EXCLUDED.base_url, updated_at = now()
+            SET subject_id = EXCLUDED.subject_id, name = EXCLUDED.name,
+                folder_id = EXCLUDED.folder_id, base_url = EXCLUDED.base_url, updated_at = now()
         """,
-        (search_id, name, folder_id, base_url),
+        (search_id, subject_id, name, folder_id, base_url),
     )
 
 
-def insert_theme(conn, search_id: str, theme: Theme, date_from, date_to) -> str:
+def insert_theme(conn, search_id: str, theme: Theme, date_from, date_to,
+                 subject_id: str | None = None) -> str:
     """Insert/refresh a theme + its topics for this pull window; return the theme_id."""
     theme_id = get_consistent_hash(f"pulsar-theme:{search_id}:{date_from}:{date_to}:{theme.title}")
     conn.execute(
         """
         INSERT INTO pulsar_themes
-            (theme_id, search_id, title, summary, sentiment, volume, date_from, date_to)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            (theme_id, search_id, subject_id, title, summary, sentiment, volume, date_from, date_to)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (theme_id) DO UPDATE
-            SET summary = EXCLUDED.summary, sentiment = EXCLUDED.sentiment, volume = EXCLUDED.volume
+            SET subject_id = EXCLUDED.subject_id, summary = EXCLUDED.summary,
+                sentiment = EXCLUDED.sentiment, volume = EXCLUDED.volume
         """,
-        (theme_id, search_id, theme.title, theme.summary, theme.sentiment, theme.volume, date_from, date_to),
+        (theme_id, search_id, subject_id, theme.title, theme.summary, theme.sentiment, theme.volume, date_from, date_to),
     )
     for t in theme.topics:
         topic_id = get_consistent_hash(f"pulsar-topic:{theme_id}:{t.label}")

--- a/rrs/schemas/pulsar_models.py
+++ b/rrs/schemas/pulsar_models.py
@@ -32,6 +32,7 @@ class PulsarSearch(RRSBase):
     __tablename__ = "pulsar_searches"
 
     search_id = Column(String, primary_key=True)  # Pulsar search id, e.g. "201830"
+    subject_id = Column(String, ForeignKey("subjects.subject_id"), nullable=True)
     name = Column(String, nullable=True)
     folder_id = Column(String, nullable=True)
     base_url = Column(String, nullable=True)
@@ -51,6 +52,7 @@ class PulsarTheme(RRSBase):
 
     theme_id = Column(String, primary_key=True)  # surrogate (hash of search+window+title)
     search_id = Column(String, ForeignKey("pulsar_searches.search_id"), nullable=False)
+    subject_id = Column(String, ForeignKey("subjects.subject_id"), nullable=True)
     title = Column(String, nullable=True)
     summary = Column(Text, nullable=True)
     sentiment = Column(String, nullable=True)


### PR DESCRIPTION
## Summary

- **New entry point**: `rrs/pulsar/fetch_weekly_themes_client.py` is now the main Pulsar pipeline. It fetches themes directly from the Pulsar GraphQL API using a permanent API key — no browser automation required.
- **How it works**: calls `topics` to get the top NLP topics and their co-occurrence graph, groups them into themes via a greedy co-occurrence algorithm, enriches each theme with an AI-generated title/sentiment/body via `summary` + `narrativesSummarization`, then translates all narratives to French in a single batch call before storing.
- **French translation**: after all themes are generated, titles and bodies are translated to French in one batch Google Translate call (`deep-translator`). Sentiment values are mapped via a lookup dict (`positive` → `positif`, etc.). Translation happens as a post-processing step, cleanly separated from the Pulsar API calls.
- **`PulsarPostsClient` updated**: `team` header is now optional (not needed for API key auth); added `from_api_key()` classmethod so both the old session-token flow and the new API key flow are supported.
- **`PulsarSettings` updated**: added `api_key`, `relevance_mention_tag_ids` (JSON array env var), and `days_back` fields read from env.
- **Lighter Docker image**: `Dockerfile.pulsar` now uses `python:3.12-slim` instead of the heavy `mcr.microsoft.com/playwright/python` base image. `playwright` and `openpyxl` removed from the `pulsar` poetry group.
- **`run.py` marked deprecated**: the old browser-based pipeline (`download_themes_xlsx` → parse XLSX → store → fetch posts) is kept but marked deprecated in favour of the new API-key approach.

## New env vars

| Variable | Required | Default | Description |
|---|---|---|---|
| `PULSAR_API_KEY` | Yes (new pipeline) | — | Permanent Pulsar API key |
| `PULSAR_DAYS_BACK` | No | `7` | Look-back window in days |
| `PULSAR_RELEVANCE_MENTION_TAG_IDS` | No | `[]` | JSON array of relevance tag IDs |

## Test plan

- [x] Run `poetry install --only pulsar` and confirm no errors
- [x] Set `PULSAR_API_KEY`, `PULSAR_SEARCH_ID` and run `python -m rrs.pulsar.fetch_weekly_themes_client` — confirm themes JSON written in French and DB rows inserted
- [x] Confirm the new Docker image builds: `docker build -f rrs/Dockerfile.pulsar .`