### PR TITLE
Add LLM misinformation filter to Pulsar post pipeline

### DIFF
--- a/infrastructure/kestra/flows/main_quotaclimat_barometre.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimat_barometre.yaml
@@ -126,7 +126,7 @@ tasks:
       BUCKET_OUTPUT_FOLDER: label-misinformation-input
       COUNTRY: france
       ENV: production
-      KEYWORDS_URL: https://keywords.mediatree.fr/api/v2/subtitle/
+      KEYWORDS_URL: https://keywords.mediatree.fr/api/export/single
       LABEL_MISINFORMATION_OVERWRITE: 1
       LABEL_STUDIO_PROJECT: 6
       LABEL_STUDIO_PROJECT_ID: 4

--- a/infrastructure/kestra/flows/main_quotaclimat_barometrecatchup.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimat_barometrecatchup.yaml
@@ -16,6 +16,16 @@ triggers:
     cron: "0 3 * * *"
     timezone: Europe/Paris
 
+inputs:
+  - id: days_back
+    type: INT
+    default: 7
+    description: Days prior to current date. Defaults to 7.
+  - id: selected_channel
+    type: STRING
+    required: false
+    description: "Runs the pipeline on a single channel."
+
 tasks:
   - id: ingest_data_to_s3
     type: io.kestra.plugin.docker.Run
@@ -34,6 +44,7 @@ tasks:
       API_TO_S3_CONCURRENCY: 10
       BUCKET_NAME: mediatree
       COUNTRY: fra
+      CHANNEL: "{{ inputs.selected_channel }}"
       ENV: prod
       KEYWORDS_URL: https://keywords.mediatree.fr/api/subtitle/
       LOGLEVEL: INFO
@@ -42,7 +53,7 @@ tasks:
       MODIN_CPUS: 2
       MODIN_ENGINE: python
       MODIN_MEMORY: 3000000000
-      NUMBER_OF_PREVIOUS_DAYS: 7
+      NUMBER_OF_PREVIOUS_DAYS: "{{ inputs.days_back }}"
       OMP_NUM_THREADS: 3
       PORT_HS: 5666
       BUCKET: "{{ secret('SCW_ACCESS') }}"
@@ -69,6 +80,7 @@ tasks:
       BUCKET_NAME: mediatree
       COMPARE_DURATION: true
       COUNTRY: fra
+      CHANNEL: "{{ inputs.selected_channel }}"
       DBT_PROFILES_DIR: /app/my_dbt_project/dbt
       DBT_PROJECT_DIR: /app/my_dbt_project
       ENV: prod
@@ -81,6 +93,7 @@ tasks:
       MODIN_CPUS: 2
       MODIN_ENGINE: ray
       MODIN_MEMORY: 3000000000
+      NUMBER_OF_PREVIOUS_DAYS: "{{ inputs.days_back }}"
       POSTGRES_DB: barometre
       POSTGRES_PORT: 22737
       RAY_COLOR_PREFIX: 1
@@ -114,6 +127,7 @@ tasks:
       BUCKET_OUTPUT: mediatree
       BUCKET_OUTPUT_FOLDER: label-misinformation-input
       COUNTRY: france
+      CHANNEL: "{{ inputs.selected_channel }}"
       ENV: production
       KEYWORDS_URL: https://keywords.mediatree.fr/api/export/single
       LABEL_STUDIO_PROJECT: 6
@@ -124,7 +138,7 @@ tasks:
       MEDIATREE_USER: quotaclimat
       MODEL_NAME: ft:gpt-4o-mini-2024-07-18:personal::B1xWiJRm
       MODIN_MEMORY: 3000000000
-      NUMBER_OF_PREVIOUS_DAYS: 7
+      NUMBER_OF_PREVIOUS_DAYS: "{{ inputs.days_back }}"
       POSTGRES_DB: barometre
       POSTGRES_PORT: 22737
       RAY_COLOR_PREFIX: 1

--- a/infrastructure/kestra/flows/main_quotaclimat_barometrecatchup.yaml
+++ b/infrastructure/kestra/flows/main_quotaclimat_barometrecatchup.yaml
@@ -115,7 +115,7 @@ tasks:
       BUCKET_OUTPUT_FOLDER: label-misinformation-input
       COUNTRY: france
       ENV: production
-      KEYWORDS_URL: https://keywords.mediatree.fr/api/v2/subtitle/
+      KEYWORDS_URL: https://keywords.mediatree.fr/api/export/single
       LABEL_STUDIO_PROJECT: 6
       LABEL_STUDIO_PROJECT_ID: 4
       LABEL_STUDIO_URL: https://barometre7kfudatm-labelstudio.functions.fnc.fr-par.scw.cloud

--- a/infrastructure/kestra/flows/main_rrs_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrs_pulsarthemes.yml
@@ -63,6 +63,7 @@ tasks:
           - rrs.pulsar.fetch_weekly_themes_client
         env:
           PYTHONPATH: /app
+          MISTRAL_API_KEY: "{{ secret('MISTRAL_API_KEY') }}"
           PULSAR_API_KEY: "{{ secret('PULSAR_API_KEY') }}"
           PULSAR_BASE_URL: "{{ secret('PULSAR_BASE_URL') }}"
           PULSAR_EMAIL: "{{ secret('PULSAR_EMAIL') }}"

--- a/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrsdev_pulsarthemes.yml
@@ -61,6 +61,7 @@ tasks:
           - rrs.pulsar.fetch_weekly_themes_client
         env:
           PYTHONPATH: /app
+          MISTRAL_API_KEY: "{{ secret('MISTRAL_API_KEY') }}"
           PULSAR_API_KEY: "{{ secret('PULSAR_API_KEY') }}"
           PULSAR_BASE_URL: "{{ secret('PULSAR_BASE_URL') }}"
           PULSAR_EMAIL: "{{ secret('PULSAR_EMAIL') }}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -289,7 +289,7 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -331,7 +331,7 @@ version = "4.14.1"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
     {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
@@ -2224,7 +2224,7 @@ version = "0.4.0"
 description = "Like `typing._eval_type`, but lets older Python versions use newer typing features."
 optional = false
 python-versions = ">=3.7"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "eval_type_backport-0.4.0-py3-none-any.whl", hash = "sha256:ad5e2a8db71b6696a56eafb938b0f5a337d3217f256b8e158b469422b4772b20"},
     {file = "eval_type_backport-0.4.0.tar.gz", hash = "sha256:8397d25e6524c2e67b9576bb0636be27dea2192017711220c534ec2de921e9b0"},
@@ -2670,8 +2670,8 @@ googleapis-common-protos = ">=1.63.2,<2.0.0"
 grpcio = {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
 grpcio-status = {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
 proto-plus = [
-    {version = ">=1.24.0,<2.0.0"},
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.24.0,<2.0.0"},
 ]
 protobuf = ">=5.29.6,<8.0.0"
 requests = ">=2.33.0,<3.0.0"
@@ -2748,8 +2748,8 @@ grpcio-status = ">=1.51.3"
 opentelemetry-api = ">=1.27.0"
 opentelemetry-sdk = ">=1.27.0"
 proto-plus = [
-    {version = ">=1.22.3,<2.0.0"},
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
 ]
 protobuf = ">=4.25.8,<8.0.0"
 
@@ -3043,7 +3043,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -3094,7 +3094,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -3116,7 +3116,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -3234,7 +3234,7 @@ version = "8.7.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
     {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
@@ -3734,7 +3734,7 @@ version = "1.1.6"
 description = "A lightweight and powerful JSONPath implementation for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "jsonpath_python-1.1.6-py3-none-any.whl", hash = "sha256:a1c50afd8d3fbbaf47a4873bc890dcb3c15da96f5c020327977d844d8731a2d4"},
     {file = "jsonpath_python-1.1.6.tar.gz", hash = "sha256:dded9932b4ec41fb8726e09c83afa4e6be618f938c2db287cc2a81723c639671"},
@@ -4602,7 +4602,7 @@ version = "2.6.0"
 description = "Python Client SDK for the Mistral AI API."
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "mistralai-2.6.0-py3-none-any.whl", hash = "sha256:4b7202b0cab84ea03f8ff4a933c8cfc615b3057520d9d76467c07aa23939dab2"},
     {file = "mistralai-2.6.0.tar.gz", hash = "sha256:531a86292ad498fc0fcd6dfcd480a3f4db9e92f558e14ffb22172824831e3a6e"},
@@ -5515,7 +5515,7 @@ version = "1.39.1"
 description = "OpenTelemetry Python API"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950"},
     {file = "opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c"},
@@ -5548,7 +5548,7 @@ version = "0.60b1"
 description = "OpenTelemetry Semantic Conventions"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb"},
     {file = "opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953"},
@@ -5727,8 +5727,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -6820,7 +6820,7 @@ version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
     {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
@@ -6842,7 +6842,7 @@ version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
@@ -7197,7 +7197,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -8741,7 +8741,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -9910,7 +9910,7 @@ version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
@@ -10356,7 +10356,7 @@ version = "4.1.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"},
     {file = "zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"},
@@ -10430,4 +10430,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "381f3a63afa9f01b8458313e2423dc2d4cfe70a4ce92d06ae0e16ee110c66fd1"
+content-hash = "190246a2446afa88a4194069cb7064b9fd383a9d1ae17ad4e4550b5bb495d685"

--- a/poetry.lock
+++ b/poetry.lock
@@ -393,7 +393,7 @@ version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -843,7 +843,7 @@ version = "2.1.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0"},
     {file = "cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd"},
@@ -946,7 +946,7 @@ files = [
     {file = "cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210"},
     {file = "cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9"},
 ]
-markers = {dev = "(sys_platform == \"linux\" or sys_platform == \"darwin\" or implementation_name == \"pypy\") and (platform_python_implementation != \"PyPy\" or sys_platform == \"darwin\" or implementation_name == \"pypy\")", rrs = "platform_python_implementation != \"PyPy\""}
+markers = {dev = "(sys_platform == \"linux\" or sys_platform == \"darwin\" or implementation_name == \"pypy\") and (platform_python_implementation != \"PyPy\" or sys_platform == \"darwin\" or implementation_name == \"pypy\")", pulsar = "platform_python_implementation != \"PyPy\"", rrs = "platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -1117,11 +1117,12 @@ version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
     {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
+markers = {pulsar = "sys_platform != \"emscripten\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -1162,12 +1163,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\" or os_name == \"nt\""}
+markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\" or os_name == \"nt\"", pulsar = "sys_platform != \"emscripten\" and platform_system == \"Windows\""}
 
 [[package]]
 name = "comm"
@@ -1422,7 +1423,7 @@ version = "49.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
     {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
@@ -3141,7 +3142,7 @@ version = "0.4.3"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
 optional = false
 python-versions = ">=3.9"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
@@ -3749,7 +3750,7 @@ version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
     {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
@@ -3771,7 +3772,7 @@ version = "2025.9.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -4557,7 +4558,7 @@ version = "1.28.1"
 description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df"},
     {file = "mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683"},
@@ -6807,12 +6808,12 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "rrs"]
+groups = ["main", "dev", "pulsar", "rrs"]
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "implementation_name != \"PyPy\"", dev = "(sys_platform == \"linux\" or sys_platform == \"darwin\" or implementation_name == \"pypy\") and (platform_python_implementation != \"PyPy\" or sys_platform == \"darwin\" or implementation_name == \"pypy\") and implementation_name != \"PyPy\"", rrs = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
+markers = {main = "implementation_name != \"PyPy\"", dev = "(sys_platform == \"linux\" or sys_platform == \"darwin\" or implementation_name == \"pypy\") and (platform_python_implementation != \"PyPy\" or sys_platform == \"darwin\" or implementation_name == \"pypy\") and implementation_name != \"PyPy\"", pulsar = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", rrs = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -6975,7 +6976,7 @@ version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
     {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
@@ -7042,7 +7043,7 @@ version = "2.13.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
     {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
@@ -7247,7 +7248,7 @@ version = "0.0.32"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
     {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
@@ -7301,7 +7302,7 @@ version = "312"
 description = "Python for Windows Extensions"
 optional = false
 python-versions = ">=3.9"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e"},
@@ -7699,7 +7700,7 @@ version = "0.37.0"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
     {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
@@ -7930,7 +7931,7 @@ version = "2026.6.3"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "rrs"]
+groups = ["main", "pulsar", "rrs"]
 files = [
     {file = "rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7"},
     {file = "rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911"},
@@ -9183,7 +9184,7 @@ version = "3.4.5"
 description = "SSE plugin for Starlette"
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296"},
     {file = "sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a"},
@@ -9272,7 +9273,7 @@ version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
     {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
@@ -9955,7 +9956,7 @@ version = "0.50.2"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 markers = "sys_platform != \"emscripten\""
 files = [
     {file = "uvicorn-0.50.2-py3-none-any.whl", hash = "sha256:4ae72a385630bcc17a0adb8290f26c993865e0b43a2114c2aab96420172c056a"},
@@ -10430,4 +10431,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "190246a2446afa88a4194069cb7064b9fd383a9d1ae17ad4e4550b5bb495d685"
+content-hash = "2fe34257301e2b0ef624fd2b7b2608b61bdcc107fce4823c3bd84046b46f97e6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1168,7 +1168,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\" or os_name == \"nt\"", pulsar = "sys_platform != \"emscripten\" and platform_system == \"Windows\""}
+markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\" or os_name == \"nt\""}
 
 [[package]]
 name = "comm"
@@ -2893,7 +2893,7 @@ version = "2.1.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "griffe-2.1.0-py3-none-any.whl", hash = "sha256:2ccdab17fb9cd76f278d7b5611cfc8f68cbe846d8d48df63dff80b62ecfa6f65"},
     {file = "griffe-2.1.0.tar.gz", hash = "sha256:c58845df5a364feaabd05ee8c767b97b03e478da8aa18b9923553c812fb0d955"},
@@ -2912,7 +2912,7 @@ version = "2.1.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "griffecli-2.1.0-py3-none-any.whl", hash = "sha256:6e22b1423d562ddc510997b4be1fe89de59e19dcff78831c0f4bfc3b8134a718"},
     {file = "griffecli-2.1.0.tar.gz", hash = "sha256:2ff68dbee9395fdb668b10374c51683392d697b226ac60159798f4add1ee716c"},
@@ -2928,7 +2928,7 @@ version = "2.1.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.10"
-groups = ["rrs"]
+groups = ["pulsar", "rrs"]
 files = [
     {file = "griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00"},
     {file = "griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813"},
@@ -10431,4 +10431,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "2fe34257301e2b0ef624fd2b7b2608b61bdcc107fce4823c3bd84046b46f97e6"
+content-hash = "86c68810d8dcdb905278776ae2a31d745600b706a9ce4f9bc5c35a45e6698a3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ deep-translator = "^1.11"
 openpyxl = "^3.1.5"
 mistralai = "^2.5.0"
 mcp = "^1.28.1"
+griffe = "^2.1.0"
 
 [tool.pytest_env]
 CLEAN_CACHE_ON_EXIT=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ python-dotenv = ">=1.0"
 tzdata = "^2026.2"
 deep-translator = "^1.11"
 openpyxl = "^3.1.5"
+mistralai = "^2.5.0"
 
 [tool.pytest_env]
 CLEAN_CACHE_ON_EXIT=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ tzdata = "^2026.2"
 deep-translator = "^1.11"
 openpyxl = "^3.1.5"
 mistralai = "^2.5.0"
+mcp = "^1.28.1"
 
 [tool.pytest_env]
 CLEAN_CACHE_ON_EXIT=true

--- a/rrs/misinformation_detection/classifier.py
+++ b/rrs/misinformation_detection/classifier.py
@@ -1,0 +1,52 @@
+"""Reusable per-item Mistral classification core for misinformation detection.
+
+Kept lean (only mistralai + stdlib) so it can be imported from any image that
+has the mistralai package — including the pulsar image — without pulling in
+duckdb, pandas, or other heavy deps from main.py.
+"""
+
+import asyncio
+import logging
+from typing import Literal
+
+from mistralai.client import Mistral
+from mistralai.client.types import BaseModel
+from mistralai.extra.run.context import RunContext
+
+PRICING = {
+    "mistral-small-2603": (0.15, 0.60),
+    "mistral-small-3.2": (0.10, 0.30),
+    "mistral-medium-2505": (0.40, 2.00),
+    "mistral-large-2411": (2.00, 6.00),
+}
+
+
+class MisinfoResult(BaseModel):
+    label: Literal["oui", "non", "incertain"]
+    score: float
+    justification: str
+
+
+async def classify_one(
+    client: Mistral,
+    semaphore: asyncio.Semaphore,
+    system_prompt: str,
+    index: int,
+    total: int,
+    text: str,
+    model: str,
+    user_prefix: str = "Analyse cet extrait et détecte une éventuelle désinformation :\n\n",
+) -> tuple[MisinfoResult, int, int]:
+    """Classify a single text.  Returns (result, input_tokens_est, output_tokens_est)."""
+    async with semaphore:
+        logging.info(f"[{index + 1}/{total}] Classifying...")
+        async with RunContext(model=model, output_format=MisinfoResult) as run_ctx:
+            run_result = await client.beta.conversations.run_async(
+                run_ctx=run_ctx,
+                instructions=system_prompt,
+                inputs=[{"role": "user", "content": f"{user_prefix}{text}"}],
+            )
+        output_text = run_result.output_entries[0].content if run_result.output_entries else ""
+        input_tokens = len(system_prompt + text) // 4
+        output_tokens = len(output_text) // 4
+        return run_result.output_as_model, input_tokens, output_tokens

--- a/rrs/misinformation_detection/definitions.py
+++ b/rrs/misinformation_detection/definitions.py
@@ -17,6 +17,34 @@ celle portant sur la justice, l'immigration et l'action policière. Les faits su
 ne sont retenus que lorsqu'ils sont explicitement mobilisés dans le débat public français à des \
 fins de comparaison, d'analogie ou d'instrumentalisation politique
 """.strip(),
+
+    "climate": """
+La désinformation est définie ici comme tout contenu qui contredit le consensus scientifique \
+établi ou propage des narratifs trompeurs sur le changement climatique, en couvrant trois \
+dimensions : la science climatique, l'action climatique, et l'ensemble des solutions \
+d'atténuation et d'adaptation telles que décrites dans les rapports du GIEC.
+
+Science climatique : sont visées les affirmations niant ou minimisant les causes humaines du \
+réchauffement climatique, contestant l'existence ou la gravité de la crise climatique, \
+déformant les projections scientifiques du GIEC, ou présentant le consensus scientifique comme \
+incertain ou fabriqué.
+
+Action climatique : sont visés les narratifs discréditant les politiques climatiques nationales \
+ou internationales (Accord de Paris, taxonomie verte, lois climat), les affirmations présentant \
+l'inaction comme légitime ou la transition comme inutile, ainsi que les contenus instrumentalisant \
+de fausses données économiques ou sociales pour bloquer toute régulation climatique.
+
+Solutions d'atténuation et d'adaptation : sont visées les affirmations trompant sur l'efficacité, \
+le coût ou la faisabilité des solutions reconnues par le GIEC — énergies renouvelables, efficacité \
+énergétique, reforestation, agriculture bas-carbone, capture de carbone, adaptation des \
+infrastructures — ainsi que les comparaisons déloyales avec les énergies fossiles ou le nucléaire \
+visant à disqualifier ces solutions sans base factuelle sérieuse.
+
+Sont également concernés les chiffres falsifiés ou sortis de contexte, les corrélations abusives, \
+les théories du complot sur les motivations des scientifiques ou des acteurs de la transition, et \
+tout amalgame visant à associer l'action climatique à des agendas idéologiques sans rapport avec \
+les faits
+""".strip(),
 }
 
 
@@ -31,6 +59,7 @@ def get_definition(subject: str) -> str:
 
 
 def build_system_prompt(subject: str) -> str:
+    """Prompt for TV/radio transcript classification."""
     definition = get_definition(subject)
     return f"""Tu es un expert en détection de désinformation médiatique en France. \
 Ta tâche est d'analyser des extraits de programmes télévisés ou radiophoniques \
@@ -50,3 +79,5 @@ La justification doit être courte.
 - "non" : l'extrait ne contient pas de désinformation (y compris les publicités)
 - "incertain" : l'extrait est ambigu ou insuffisant pour conclure
 """
+
+

--- a/rrs/misinformation_detection/main.py
+++ b/rrs/misinformation_detection/main.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 import os
 from datetime import date, datetime, timedelta, timezone
-from typing import Literal, Optional
+from typing import Optional
 from urllib.parse import quote
 
 import duckdb
@@ -12,9 +12,8 @@ import psycopg
 from dotenv import load_dotenv
 
 from mistralai.client import Mistral
-from mistralai.client.types import BaseModel
-from mistralai.extra.run.context import RunContext
 from rrs.dictionary.upsert_subjects import subject_id as make_subject_id
+from rrs.misinformation_detection.classifier import PRICING, MisinfoResult, classify_one
 from rrs.misinformation_detection.definitions import build_system_prompt
 from rrs.utils.generate_id import get_consistent_hash
 
@@ -155,48 +154,6 @@ def _enrich_with_plaintext(segments: pd.DataFrame) -> pd.DataFrame:
 
 # ── LLM classification ────────────────────────────────────────────────────────
 
-PRICING = {
-    "mistral-small-2603": (0.15, 0.60),
-    "mistral-small-3.2": (0.10, 0.30),
-    "mistral-medium-2505": (0.40, 2.00),
-    "mistral-large-2411": (2.00, 6.00),
-}
-
-
-class MisinfoResult(BaseModel):
-    label: Literal["oui", "non", "incertain"]
-    score: float
-    justification: str
-
-
-async def _classify_one(
-    client: Mistral,
-    semaphore: asyncio.Semaphore,
-    system_prompt: str,
-    index: int,
-    total: int,
-    text: str,
-    model: str,
-) -> tuple[MisinfoResult, int, int]:
-    async with semaphore:
-        logging.info(f"[{index + 1}/{total}] Classifying...")
-        async with RunContext(model=model, output_format=MisinfoResult) as run_ctx:
-            run_result = await client.beta.conversations.run_async(
-                run_ctx=run_ctx,
-                instructions=system_prompt,
-                inputs=[
-                    {
-                        "role": "user",
-                        "content": f"Analyse cet extrait et détecte une éventuelle désinformation :\n\n{text}",
-                    }
-                ],
-            )
-        output_text = run_result.output_entries[0].content if run_result.output_entries else ""
-        input_tokens = len(system_prompt + text) // 4
-        output_tokens = len(output_text) // 4
-        return run_result.output_as_model, input_tokens, output_tokens
-
-
 async def classify_segments(
     df: pd.DataFrame,
     subject: str,
@@ -216,7 +173,7 @@ async def classify_segments(
 
     texts = df["plaintext"].tolist()
     tasks = [
-        _classify_one(client, semaphore, system_prompt, i, len(df), str(t), model)
+        classify_one(client, semaphore, system_prompt, i, len(df), str(t), model)
         if not (pd.isna(t) or str(t).strip() == "")
         else _skip()
         for i, t in enumerate(texts)

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -56,12 +56,19 @@ CONFIG (environment variables):
                                 running this script standalone.
 """
 
+import asyncio
 import json
+import logging
+import os
 import time
 from datetime import datetime, timedelta, timezone
 
 import requests
 from deep_translator import GoogleTranslator
+from mistralai.client import Mistral
+
+from rrs.misinformation_detection.classifier import classify_one
+from rrs.pulsar.prompts import build_pulsar_system_prompt
 
 from rrs.pulsar import store
 from rrs.pulsar.parse_themes import Theme, Topic
@@ -88,6 +95,54 @@ _SENTIMENT_FR = {
     "neutral": "neutre",
     "mixed": "mixte",
 }
+
+
+_MISINFO_MAX_CHARS = 3000  # cap per post to control token usage
+_MISINFO_MODEL_DEFAULT = "mistral-small-2603"
+_MISINFO_CONCURRENCY = 5
+
+
+async def _classify_posts_async(posts: list[dict], subject: str, model: str,
+                                concurrency: int) -> list[dict]:
+    api_key = os.environ.get("MISTRAL_API_KEY")
+    if not api_key:
+        logging.warning("MISTRAL_API_KEY not set — skipping misinformation classification.")
+        return posts
+
+    system_prompt = build_pulsar_system_prompt(subject or "climate")
+    client = Mistral(api_key=api_key)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _safe_classify(i, post):
+        text = ((post.get("content") or "") + "\n\n" + (post.get("title") or "")).strip()
+        text = text[:_MISINFO_MAX_CHARS]
+        if not text:
+            return post
+        try:
+            misinfo, _, _ = await classify_one(
+                client, semaphore, system_prompt, i, len(posts), text, model,
+                user_prefix="Analyse cet article :\n\n",
+            )
+            return {**post, "misinfo_label": misinfo.label, "misinfo_score": misinfo.score,
+                    "misinfo_justification": misinfo.justification}
+        except Exception as exc:
+            logging.error(f"  misinfo classification error on post {i}: {exc}")
+            return post
+
+    tasks = [_safe_classify(i, p) for i, p in enumerate(posts)]
+    return list(await asyncio.gather(*tasks))
+
+
+def classify_posts(posts: list[dict], subject: str | None,
+                   model: str = _MISINFO_MODEL_DEFAULT,
+                   concurrency: int = _MISINFO_CONCURRENCY) -> list[dict]:
+    """Classify posts for misinformation using Mistral. Returns posts with misinfo_* fields added.
+
+    Skips silently if MISTRAL_API_KEY is not set.
+    """
+    if not posts:
+        return posts
+    return asyncio.run(_classify_posts_async(posts, subject or "", model, concurrency))
 
 
 def _translate_to_french(title: str, body: str) -> tuple[str, str]:
@@ -296,6 +351,8 @@ def run() -> None:
             posts = posts_client.fetch_theme_posts(
                 s.search_id, topic_labels, date_from_dt, date_to_dt, limit=s.top_n
             )
+            posts = classify_posts(posts, subject=s.subject)
+            posts = [p for p in posts if p.get("misinfo_label") != "non"]
             total_posts += store.upsert_posts(conn, s.search_id, theme_id, posts)
         conn.commit()
 

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -91,7 +91,9 @@ STAT_TYPE = "VISIBILITY"
 
 _SENTIMENT_FR = {
     "positive": "positif",
+    "VERY_POSITIVE": "positif",
     "negative": "négatif",
+    "VERY_NEGATIVE": "négatif",
     "neutral": "neutre",
     "mixed": "mixte",
 }

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -128,7 +128,7 @@ async def _classify_posts_async(posts: list[dict], subject: str, model: str,
             return {**post, "misinfo_label": misinfo.label, "misinfo_score": misinfo.score,
                     "misinfo_justification": misinfo.justification}
         except Exception as exc:
-            logging.error(f"  misinfo classification error on post {i}: {exc}")
+            logging.error(f"  misinfo classification error on post {i}:\n {post}\n{exc}")
             return post
 
     tasks = [_safe_classify(i, p) for i, p in enumerate(posts)]

--- a/rrs/pulsar/prompts.py
+++ b/rrs/pulsar/prompts.py
@@ -1,0 +1,28 @@
+"""System prompts for Pulsar post classification."""
+
+from rrs.misinformation_detection.definitions import get_definition
+
+
+def build_pulsar_system_prompt(subject: str) -> str:
+    """Prompt for social media / online news article classification."""
+    definition = get_definition(subject)
+    return f"""Tu es un vérificateur de faits spécialisé dans les réseaux sociaux et les médias \
+en ligne. Ta tâche est d'analyser des articles, publications ou posts issus de sources \
+numériques (presse en ligne, réseaux sociaux, blogs, forums) et de déterminer s'ils \
+contiennent de la désinformation selon la définition suivante :
+
+{definition}
+
+IMPORTANT : certains contenus peuvent être des publicités, des communiqués de presse \
+promotionnels ou des contenus sponsorisés. Dans ce cas, indique-le et considère qu'il \
+n'y a pas de désinformation à proprement parler.
+
+IMPORTANT : concentre-toi uniquement sur les affirmations factuelles vérifiables. \
+Une opinion clairement exprimée comme telle n'est pas de la désinformation.
+
+La justification doit être courte (1-2 phrases maximum).
+
+- "oui"       : le contenu contient de la désinformation telle que définie ci-dessus
+- "non"       : le contenu ne contient pas de désinformation
+- "incertain" : le contenu est ambigu, incomplet ou insuffisant pour conclure
+"""

--- a/rrs/pulsar/settings.py
+++ b/rrs/pulsar/settings.py
@@ -36,7 +36,8 @@ class PulsarSettings:
     api_key: str | None = None
     relevance_mention_tag_ids: list[str] = field(default_factory=list)
     days_back: int = 7
-    subject_id: str | None = None
+    subject: str | None = None          # raw subject name (e.g. "climate"), used for prompts
+    subject_id: str | None = None       # SHA-256 hash of subject, used as FK
     start_date: datetime | None = None  # explicit window start; falls back to days_back if unset
     end_date: datetime | None = None    # explicit window end; falls back to now() if unset
 
@@ -79,7 +80,8 @@ class PulsarSettings:
             api_key=os.getenv("PULSAR_API_KEY"),
             relevance_mention_tag_ids=relevance_mention_tag_ids,
             days_back=int(os.getenv("PULSAR_DAYS_BACK", "7")),
-            subject_id=get_consistent_hash(subject) if (subject := os.getenv("SUBJECT")) else None,
+            subject=subject if (subject := os.getenv("SUBJECT")) else None,
+            subject_id=get_consistent_hash(subject) if subject else None,
             start_date=_parse_date(v) if (v := os.getenv("PULSAR_START_DATE")) else None,
             end_date=_parse_date(v) if (v := os.getenv("PULSAR_END_DATE")) else None,
         )


### PR DESCRIPTION
## Summary

- Extracts the reusable Mistral classification core (`MisinfoResult`, `classify_one`, `PRICING`) from `rrs/misinformation_detection/main.py` into a new thin module `rrs/misinformation_detection/classifier.py`, importable from any image without pulling in duckdb/pandas
- Adds a `"climate"` subject definition to `definitions.py` covering three IPCC-aligned pillars: climate science, climate action, and mitigation/adaptation solutions
- Adds `rrs/pulsar/prompts.py` with `build_pulsar_system_prompt()` — a social media / online news fact-checker prompt that embeds the subject definition, kept in the pulsar folder rather than the misinformation module
- Adds `classify_posts()` to `fetch_weekly_themes_client.py`: after fetching top posts per theme, each post is classified by Mistral (concurrently, up to 5 at a time) as `"oui"` / `"non"` / `"incertain"`; posts labelled `"non"` are filtered out and never written to the DB; classification is silently skipped if `MISTRAL_API_KEY` is not set
- Adds `subject` (raw string) alongside `subject_id` (hash) to `PulsarSettings` so the prompt can reference the subject by name
- Adds `mistralai = "^2.5.0"` to the `pulsar` poetry dependency group

## Test plan

- [x] Set `MISTRAL_API_KEY` and run `python -m rrs.pulsar.fetch_weekly_themes_client` locally — confirm classification logs appear per post and `"non"` posts are absent from `pulsar_posts`
- [x] Run without `MISTRAL_API_KEY` — confirm pipeline completes normally (all posts saved, warning logged)
- [x] Confirm `rrs/misinformation_detection/main.py` still works end-to-end (imports from `classifier.py`, same behaviour as before)