### PR TITLE
Fix/update sud radio api call

### DIFF
--- a/analyse/mediatree/test_program_durations.py
+++ b/analyse/mediatree/test_program_durations.py
@@ -21,9 +21,6 @@ logging.basicConfig(
     filename="channel_coverages.log", encoding="utf-8", level=logging.INFO
 )
 
-from quotaclimat.data_processing.mediatree.i8n.brazil.channel_program import (
-    channels_programs_brazil,
-)
 from quotaclimat.data_processing.mediatree.i8n.france.channel_program import (
     channels_programs_france,
 )
@@ -44,10 +41,6 @@ channels_programs_poland = [
     dict(country="poland", **channel_program)
     for channel_program in channels_programs_poland
 ]
-channels_programs_brazil = [
-    dict(country="brazil", **channel_program)
-    for channel_program in channels_programs_brazil
-]
 channels_programs_spain = [
     dict(country="spain", **channel_program)
     for channel_program in channels_programs_spain
@@ -64,7 +57,6 @@ channels_programs_belgium = [
 channel_programs_map = {
     "poland": channels_programs_poland,
     "spain": channels_programs_spain,
-    "brazil": channels_programs_brazil,
     "france": channels_programs_france,
     "germany": channels_programs_germany,
     "belgium": channels_programs_belgium,
@@ -73,7 +65,6 @@ timezones = {
     "poland": "Europe/Warsaw",
     "spain": "Europe/Madrid",
     "germany": "Europe/Berlin",
-    "brazil": "America/Sao_Paulo",
     "france": "Europe/Paris",
     "belgium": "Europe/Brussels",
 }
@@ -141,7 +132,7 @@ def get_coverages_for_day(day, country, channel_programs):
     retry = 0
     while True:
         if idx == len(channel_programs):
-            tqdm.write(f"Finshed programs")
+            tqdm.write("Finshed programs")
             break
         elif retry > 7:
             tqdm.write(f"break on {channel_programs[idx]} retry {retry}")
@@ -166,12 +157,12 @@ def get_coverages_for_day(day, country, channel_programs):
                     {
                         "date": day.strftime("%Y-%m-%d"),
                         "country": country,
-                        "channel_name": channel_program["channel_name"],
+                        "channel_name": channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                         "start": channel_program["start"],
                         "end": channel_program["end"],
                         "coverage": get_percentage_coverage(
                             token,
-                            channel_program["channel_name"],
+                            channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                             day,
                             channel_program["start"],
                             channel_program["end"],
@@ -186,12 +177,12 @@ def get_coverages_for_day(day, country, channel_programs):
                     {
                         "date": day.strftime("%Y-%m-%d"),
                         "country": country,
-                        "channel_name": channel_program["channel_name"],
+                        "channel_name": channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                         "start": channel_program["start"],
                         "end": channel_program["end"],
                         "coverage": get_percentage_coverage(
                             token,
-                            channel_program["channel_name"],
+                            channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                             day,
                             channel_program["start"],
                             channel_program["end"],
@@ -203,12 +194,12 @@ def get_coverages_for_day(day, country, channel_programs):
                     {
                         "date": day.strftime("%Y-%m-%d"),
                         "country": country,
-                        "channel_name": channel_program["channel_name"],
+                        "channel_name": channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                         "start": channel_program["start"],
                         "end": channel_program["end"],
                         "coverage": get_percentage_coverage(
                             token,
-                            channel_program["channel_name"],
+                            channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                             day,
                             channel_program["start"],
                             channel_program["end"],
@@ -223,7 +214,7 @@ def get_coverages_for_day(day, country, channel_programs):
                 {
                     "date": day.strftime("%Y-%m-%d"),
                     "country": country,
-                    "channel_name": channel_program["channel_name"],
+                    "channel_name": channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                     "start": channel_program["start"],
                     "end": channel_program["end"],
                 }
@@ -318,7 +309,7 @@ async def get_percentage_coverage_async(
     return {
         "date": date.strftime("%Y-%m-%d"),
         "country": country,
-        "channel_name": channel_name,
+        "channel_name": channel_name if channel_name != "sud-radio" else "sudradio",
         "start": start,
         "end": end,
         "total_results": result["total_results"],
@@ -368,7 +359,7 @@ async def async_get_percentage_coverage_for_day(
             and channel_program["channel_name"] != "d8"
             and channel_program["channel_name"] != "daserste"
             and channel_program["channel_name"] != "zdf-neo"
-            and not channel_program["channel_name"] in excluded_channels
+            and channel_program["channel_name"] not in excluded_channels
         ):
             if not channel_program["channel_name"] == "daserste":
                 valid_channel_programs.append(channel_program)
@@ -381,7 +372,7 @@ async def async_get_percentage_coverage_for_day(
             get_percentage_coverage_async(
                 token,
                 country,
-                channel_program["channel_name"],
+                channel_program["channel_name"] if channel_program["channel_name"] != "sud-radio" else "sudradio",
                 day,
                 channel_program["start"],
                 channel_program["end"],

--- a/quotaclimat/data_processing/mediatree/i8n/country.py
+++ b/quotaclimat/data_processing/mediatree/i8n/country.py
@@ -311,6 +311,7 @@ def get_channels(country_code=FRANCE.code) -> List[str]:
     
 
 def get_channel_title_for_name(channel_name: str, country: CountryMediaTree = FRANCE) -> str:
+    channel_name = channel_name if channel_name != "sudradio" else "sud-radio"
     logging.debug(f"Getting channel title for {channel_name} in {country.code}")
     channel_title = country.titles[channel_name]
     if channel_title is None: 

--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -87,7 +87,7 @@ def get_auth_token(password=password, user_name=USER):
 
 # see : https://keywords.mediatree.fr/docs/#api-Subtitle-SubtitleList
 def get_param_api(token, type_sub, start_epoch, channel, end_epoch, country: CountryMediaTree):
-
+    channel = channel if channel != "sud-radio" else "sudradio"
     return {
         "channel": channel,
         "token": token,

--- a/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
+++ b/quotaclimat/data_processing/mediatree/s3/api_to_s3.py
@@ -87,9 +87,8 @@ def get_auth_token(password=password, user_name=USER):
 
 # see : https://keywords.mediatree.fr/docs/#api-Subtitle-SubtitleList
 def get_param_api(token, type_sub, start_epoch, channel, end_epoch, country: CountryMediaTree):
-    channel = channel if channel != "sud-radio" else "sudradio"
     return {
-        "channel": channel,
+        "channel": channel if channel != "sud-radio" else "sudradio",
         "token": token,
         "start_gte": int(start_epoch) - country.epoch_margin,
         "start_lte": int(end_epoch) + country.epoch_margin,


### PR DESCRIPTION
On the mediatree side the `channel_name` for Sud Radio has changed from `sud-radio` to `sudradio`. In order to safeguard retrocompatibility with our historical data, we use the new name for requests but keep the legacy name for our DB.