### PR TITLE
Add keyword_lemma column for lemma-based keyword search (#611)

### DIFF
--- a/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
+++ b/my_dbt_project/models/dashboards/core_query_thematics_keywords.sql
@@ -69,7 +69,8 @@ keyword_occurrences AS (
       ELSE 'Autre'
     END AS crise_type,
     kw ->> 'theme' AS theme,
-    kw ->> 'keyword' AS keyword
+    kw ->> 'keyword' AS keyword,
+    to_tsvector('french', kw ->> 'keyword') AS keyword_lemma
   FROM public.keywords k
   LEFT JOIN public.program_metadata pm
     ON k.channel_program = pm.channel_program
@@ -102,6 +103,7 @@ SELECT
   ko.crise_type,
   ko.theme,
   ko.keyword,
+  ko.keyword_lemma,
   kmc.general,
   kmc.agriculture,
   kmc.transport,
@@ -133,6 +135,7 @@ GROUP BY
   ko.crise_type,
   ko.theme,
   ko.keyword,
+  ko.keyword_lemma,
   kmc.general,
   kmc.agriculture,
   kmc.transport,

--- a/my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords.sql
+++ b/my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords.sql
@@ -98,6 +98,7 @@ keyword_aggregates AS (
         dk.publication_day,
         dk.source_code,
         dk.keyword,
+        to_tsvector('french', dk.keyword) AS keyword_lemma,
         BOOL_AND(dk.is_hrfp) AS is_hrfp,
         COUNT(DISTINCT dk.an) AS nb_articles,
         SUM(dk.count_keyword) AS nb_keyword_occurences
@@ -114,10 +115,11 @@ keywords_with_sectors AS (
         ka.publication_day,
         ka.source_code,
         ka.keyword,
+        ka.keyword_lemma,
         ka.is_hrfp,
         ka.nb_articles,
         ka.nb_keyword_occurences,
-        CASE 
+        CASE
             WHEN sector_col = 'is_empty' THEN 'empty'
             WHEN sector_col = 'general' THEN 'General'
             WHEN sector_col = 'agriculture' THEN 'Agriculture & Alimentation'
@@ -154,6 +156,7 @@ daily_aggregates AS (
         kws.publication_day,
         kws.source_code,
         kws.keyword,
+        kws.keyword_lemma,
         kws.sector,
         kws.is_hrfp,
         kws.nb_articles,
@@ -177,6 +180,7 @@ SELECT
     sc.source_type,
     sc.media_all,
     da.keyword,
+    da.keyword_lemma,
     da.sector,
     da.nb_articles,
     da.nb_keyword_occurences,

--- a/my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords_monthly.sql
+++ b/my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords_monthly.sql
@@ -41,9 +41,10 @@ monthly_aggregates AS (
         ptk.media_all,
         ptk.source_type,
         ptk.keyword,
+        ptk.keyword_lemma,
         ptk.sector,
         ptk.is_hrfp,
-        
+
         -- Sum all counts across the month
         SUM(ptk.nb_articles) AS nb_articles,
         SUM(ptk.nb_keyword_occurences) AS nb_keyword_occurences
@@ -75,6 +76,7 @@ monthly_aggregates AS (
         ptk.media_all,
         ptk.source_type,
         ptk.keyword,
+        ptk.keyword_lemma,
         ptk.sector,
         ptk.is_hrfp
 )
@@ -86,13 +88,14 @@ SELECT
     media_all,
     source_type,
     keyword,
+    keyword_lemma,
     sector,
     nb_articles,
     nb_keyword_occurences,
     is_hrfp,
     CURRENT_TIMESTAMP AS created_at,
     CURRENT_TIMESTAMP AS updated_at
-    
+
 FROM monthly_aggregates
 
 ORDER BY

--- a/my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords_weekly.sql
+++ b/my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords_weekly.sql
@@ -41,9 +41,10 @@ weekly_aggregates AS (
         ptk.media_all,
         ptk.source_type,
         ptk.keyword,
+        ptk.keyword_lemma,
         ptk.sector,
         ptk.is_hrfp,
-        
+
         -- Sum all counts across the week
         SUM(ptk.nb_articles) AS nb_articles,
         SUM(ptk.nb_keyword_occurences) AS nb_keyword_occurences
@@ -75,6 +76,7 @@ weekly_aggregates AS (
         ptk.media_all,
         ptk.source_type,
         ptk.keyword,
+        ptk.keyword_lemma,
         ptk.sector,
         ptk.is_hrfp
 )
@@ -86,13 +88,14 @@ SELECT
     media_all,
     source_type,
     keyword,
+    keyword_lemma,
     sector,
     nb_articles,
     nb_keyword_occurences,
     is_hrfp,
     CURRENT_TIMESTAMP AS created_at,
     CURRENT_TIMESTAMP AS updated_at
-    
+
 FROM weekly_aggregates
 
 ORDER BY


### PR DESCRIPTION
## Summary

Closes #611.

The public keyword-search dashboards currently match on the raw `keyword` string, so plural/singular variants (`incendie` vs `incendies`) and multi-word phrases (`changement climatique` vs a standalone search for `climatique`) don't match each other.

This adds a `keyword_lemma` column (placed right after `keyword`) to the four thematic-keyword dbt models, computed with Postgres's built-in French Snowball stemmer — no extension required:

- `my_dbt_project/models/dashboards/core_query_thematics_keywords.sql` — audiovisual/Mediatree keywords
- `my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords.sql` — Factiva daily
- `my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords_weekly.sql` — Factiva weekly (carries the daily model's lemma through the aggregation)
- `my_dbt_project_print_media/models/dashboards/print_media_thematics_keywords_monthly.sql` — Factiva monthly (same)

`keyword_lemma` is a `tsvector` produced via `to_tsvector('french', keyword)`. Each word in the keyword is stemmed and stored as a lexeme, independent of order, e.g. `'climat':2 'chang':1` for "changement climatique".

## How to query it

Because it's a `tsvector`, not plain text, downstream queries (Metabase filters, etc.) need full-text search operators rather than `=`/`ILIKE`:

- Standard containment search (does the keyword's lemma set include this term?):
  ```sql
  keyword_lemma @@ to_tsquery('french', 'climatique')
  ```
- Exact/bounded phrase search — match a keyword only if **all** of its stemmed words are drawn from an explicit lemma allow-list (so `"climate change"` matches `{climate, change}` but `"climate change denial"` does not, because `denial` isn't in the set):
  ```sql
  tsvector_to_array(keyword_lemma) <@ ARRAY['climat', 'chang']
  ```
Which can be generated dynamically with:
```sql
  tsvector_to_array(keyword_lemma) <@ tsvector_to_array(to_tsvector('french', 'climat changement'))
```

Both the stored column and any query-side term need to go through the same `to_tsvector`/`to_tsquery` config (`french`) so stemming stays consistent on both sides.

## Test plan

- [ ] `poetry run dbt run --models core_query_thematics_keywords print_media_thematics_keywords print_media_thematics_keywords_weekly print_media_thematics_keywords_monthly --full-refresh` against a local/staging Postgres and confirm `keyword_lemma` populates correctly
- [ ] Spot-check known plural/singular pairs (e.g. `incendie`/`incendies`) and multi-word phrases (`changement climatique` vs `climatique`) resolve to overlapping lemma sets
- [ ] Confirm downstream Metabase queries/filters are updated to use `@@`/`<@` instead of string equality once this lands