### PR TITLE
Add GPU VM to barometre Terraform template

### DIFF
--- a/infrastructure/live/barometre/dev/terragrunt.hcl
+++ b/infrastructure/live/barometre/dev/terragrunt.hcl
@@ -7,15 +7,26 @@ terraform {
 }
 
 inputs = {
-  environment                       = "dev"
-  project_name                      = "barometre-dev"
-  rdb_instance_name                 = "rdb-barometre-dev"
-  postgres_admin_user               = get_env("TF_VAR_postgres_admin_user")
-  postgres_admin_password           = get_env("TF_VAR_postgres_admin_password")
+  environment             = "dev"
+  project_name            = "barometre-dev"
+  rdb_instance_name       = "rdb-barometre-dev"
+  disable_backup          = true
+  postgres_admin_user     = get_env("TF_VAR_postgres_admin_user")
+  postgres_admin_password = get_env("TF_VAR_postgres_admin_password")
   # Dev's instance root admin doubles as the database admin (no separate role like prod's barometreclimat).
-  database_admin_user                = get_env("TF_VAR_postgres_admin_user")
-  postgres_admin_password_version   = 1
-  node_type                         = "DB-DEV-S"
-  volume_type                       = "sbs_5k"
-  volume_size_in_gb                 = 20
+  database_admin_user             = get_env("TF_VAR_postgres_admin_user")
+  database_admin_password         = ""
+  barometre_rrs_read_password     = get_env("TF_VAR_barometre_rrs_read_password")
+  postgres_admin_password_version = 1
+  node_type                       = "DB-DEV-S"
+  volume_type                     = "sbs_5k"
+  volume_size_in_gb               = 20
+  # Ignored in dev — 0.0.0.0/0 is used instead (see template/database.tf).
+  acl_allowed_ips = "[]"
+
+  # GPU instance defaults (see template/variables.tf) — override here if dev needs something non-default.
+  gpu_zone                   = "fr-par-1"
+  gpu_instance_type          = "L4-1-24G"
+  gpu_image_label            = "ubuntu_jammy_gpu_os_12"
+  gpu_root_volume_size_in_gb = 100
 }

--- a/infrastructure/live/barometre/template/database.tf
+++ b/infrastructure/live/barometre/template/database.tf
@@ -83,7 +83,7 @@ locals {
 
   acl_rules = var.environment == "dev" ? [
     { ip = "0.0.0.0/0", description = "Allow all (dev only)" }
-  ]: concat(local.scaleway_job_cidrs, jsondecode(var.acl_allowed_ips))
+  ] : concat(local.scaleway_job_cidrs, jsondecode(var.acl_allowed_ips))
 }
 
 resource "scaleway_rdb_acl" "public" {

--- a/infrastructure/live/barometre/template/database.tf
+++ b/infrastructure/live/barometre/template/database.tf
@@ -81,10 +81,9 @@ locals {
     { ip = "78.232.0.0/16", description = "Scaleway DC13" },
   ]
 
-  acl_rules = var.environment == "dev" ? concat(
-    local.scaleway_job_cidrs,
-    [{ ip = "0.0.0.0/0", description = "Allow all (dev only)" }]
-  ) : concat(local.scaleway_job_cidrs, jsondecode(var.acl_allowed_ips))
+  acl_rules = var.environment == "dev" ? [
+    { ip = "0.0.0.0/0", description = "Allow all (dev only)" }
+  ]: concat(local.scaleway_job_cidrs, jsondecode(var.acl_allowed_ips))
 }
 
 resource "scaleway_rdb_acl" "public" {

--- a/infrastructure/live/barometre/template/instance.tf
+++ b/infrastructure/live/barometre/template/instance.tf
@@ -1,0 +1,44 @@
+# --- GPU VM ---
+# Used for local model inference workloads. Regular Scaleway Instances
+# auto-inject account-level SSH keys (unlike Elastic Metal — see
+# orchestrator/template/instance.tf), so no explicit scaleway_iam_ssh_key
+# resource is needed here.
+
+data "scaleway_marketplace_image" "gpu_os" {
+  zone  = var.gpu_zone
+  label = var.gpu_image_label
+}
+
+resource "scaleway_instance_server" "gpu" {
+  name       = "barometre-gpu-${var.environment == "prod" ? "inference" : "training"}-${var.environment}"
+  type       = var.gpu_instance_type
+  image      = data.scaleway_marketplace_image.gpu_os.id
+  zone       = var.gpu_zone
+  project_id = scaleway_account_project.project.id
+
+  root_volume {
+    volume_type           = "sbs_volume"
+    size_in_gb            = var.gpu_root_volume_size_in_gb
+    sbs_iops              = 5000
+    delete_on_termination = var.environment == "dev" ? true : false
+  }
+
+  # Python + uv on every environment; vllm only in prod (dev doesn't need the
+  # model-serving stack, just the interpreter/tooling).
+  cloud_init = <<-EOF
+    #cloud-config
+    package_update: true
+    packages:
+      - python3
+      - python3-pip
+      - curl
+      - ca-certificates
+    runcmd:
+      - curl -LsSf https://astral.sh/uv/install.sh | sh
+      %{if var.environment == "prod"~}
+      - /root/.local/bin/uv pip install --system vllm
+      %{endif~}
+  EOF
+
+  tags = ["barometre", "gpu", var.environment]
+}

--- a/infrastructure/live/barometre/template/instance.tf
+++ b/infrastructure/live/barometre/template/instance.tf
@@ -5,8 +5,15 @@
 # resource is needed here.
 
 data "scaleway_marketplace_image" "gpu_os" {
-  zone  = var.gpu_zone
-  label = var.gpu_image_label
+  zone          = var.gpu_zone
+  label         = var.gpu_image_label
+  instance_type = var.gpu_instance_type
+  image_type    = "instance_sbs"
+}
+
+resource "scaleway_instance_ip" "gpu" {
+  zone       = var.gpu_zone
+  project_id = scaleway_account_project.project.id
 }
 
 resource "scaleway_instance_server" "gpu" {
@@ -15,6 +22,7 @@ resource "scaleway_instance_server" "gpu" {
   image      = data.scaleway_marketplace_image.gpu_os.id
   zone       = var.gpu_zone
   project_id = scaleway_account_project.project.id
+  ip_id      = scaleway_instance_ip.gpu.id
 
   root_volume {
     volume_type           = "sbs_volume"
@@ -34,9 +42,9 @@ resource "scaleway_instance_server" "gpu" {
       - curl
       - ca-certificates
     runcmd:
-      - curl -LsSf https://astral.sh/uv/install.sh | sh
+      - UV_INSTALL_DIR=/usr/local/bin sh -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
       %{if var.environment == "prod"~}
-      - /root/.local/bin/uv pip install --system vllm
+      - /usr/local/bin/uv pip install --system vllm
       %{endif~}
   EOF
 

--- a/infrastructure/live/barometre/template/outputs.tf
+++ b/infrastructure/live/barometre/template/outputs.tf
@@ -29,3 +29,7 @@ output "mediatree_videos_api_key_secret_key" {
   value     = scaleway_iam_api_key.mediatree_videos_api_key.secret_key
   sensitive = true
 }
+
+output "gpu_instance_ip" {
+  value = scaleway_instance_server.gpu.public_ip
+}

--- a/infrastructure/live/barometre/template/outputs.tf
+++ b/infrastructure/live/barometre/template/outputs.tf
@@ -31,5 +31,5 @@ output "mediatree_videos_api_key_secret_key" {
 }
 
 output "gpu_instance_ip" {
-  value = scaleway_instance_server.gpu.public_ips[0].address
+  value = scaleway_instance_ip.gpu.address
 }

--- a/infrastructure/live/barometre/template/outputs.tf
+++ b/infrastructure/live/barometre/template/outputs.tf
@@ -31,5 +31,5 @@ output "mediatree_videos_api_key_secret_key" {
 }
 
 output "gpu_instance_ip" {
-  value = scaleway_instance_server.gpu.public_ip
+  value = scaleway_instance_server.gpu.public_ips[0].address
 }

--- a/infrastructure/live/barometre/template/variables.tf
+++ b/infrastructure/live/barometre/template/variables.tf
@@ -70,3 +70,28 @@ variable "acl_allowed_ips" {
   description = "JSON-encoded list of {ip, description} objects allowed to reach the database. Ignored in dev (0.0.0.0/0 is used instead)."
 }
 
+# --- GPU instance ---
+
+variable "gpu_zone" {
+  type        = string
+  default     = "fr-par-1"
+  description = "Scaleway zone for the GPU instance (must stock the L4 GPU offer)."
+}
+
+variable "gpu_instance_type" {
+  type        = string
+  default     = "L4-1-24G"
+  description = "Scaleway GPU instance commercial type."
+}
+
+variable "gpu_image_label" {
+  type        = string
+  default     = "ubuntu_jammy_gpu_os_12"
+  description = "Marketplace image label compatible with GPU instances (bundles NVIDIA drivers)."
+}
+
+variable "gpu_root_volume_size_in_gb" {
+  type    = number
+  default = 100
+}
+


### PR DESCRIPTION
## Summary
- Add a Scaleway GPU instance (`L4-1-24G` by default) to the barometre Terraform template, named `barometre-gpu-training-<env>` in dev and `barometre-gpu-inference-<env>` in prod.
- Root volume is `sbs_volume` (5000 IOPS), auto-deleted on termination in dev only.
- cloud-init installs `python3`, `curl`, and `uv` (to `/usr/local/bin` so it's on every user's `PATH`) on all environments; installs `vllm` via `uv` additionally when `environment == "prod"`.
- Attaches a reserved `scaleway_instance_ip` via `ip_id` so the instance gets a public IPv4, exposed as the `gpu_instance_ip` output.
- `dev/terragrunt.hcl` now sets every template variable explicitly (including the new `gpu_*` vars and the previously-missing `barometre_rrs_read_password`).

## Test plan
- [x] `tofu fmt -check` / `terragrunt hclfmt` clean (done locally)
- [x] `make env=dev target=barometre tg-plan` reviewed
- [x] `make env=dev target=barometre tg-apply`, confirm instance boots, gets a public IP, and `uv`/`python3` are usable as the `ubuntu` user
- [x] Repeat plan/apply for prod, confirm `vllm` installs via cloud-init