### PR TITLE
feat(rrs): add pulsar docker-compose service, fix crash and rate-limit knobs

### DIFF
--- a/infrastructure/kestra/flows/main_rrs_pulsarthemes.yml
+++ b/infrastructure/kestra/flows/main_rrs_pulsarthemes.yml
@@ -87,3 +87,4 @@ tasks:
           RRS_PG_DATABASE: rrs
           RRS_PG_USER: "{{ secret('RRS_PG_USER') }}"
           RRS_PG_PASSWORD: "{{ secret('RRS_PG_PASSWORD') }}"
+          CONCURRENCY: 1

--- a/rrs/docker-compose.yml
+++ b/rrs/docker-compose.yml
@@ -200,6 +200,35 @@ services:
       rrs_db:
         condition: service_healthy
 
+  pulsar:
+    build:
+      context: ../
+      dockerfile: rrs/Dockerfile.pulsar
+    environment:
+      PYTHONPATH: /app
+      RRS_PG_USER: ${RRS_PG_USER:-user}
+      RRS_PG_DATABASE: ${RRS_PG_DATABASE:-rrs_db}
+      RRS_PG_PASSWORD: ${RRS_PG_PASSWORD:-password}
+      RRS_PG_HOST: ${RRS_PG_HOST:-rrs_db}
+      RRS_PG_PORT: ${RRS_PG_PORT:-5432}
+      MISTRAL_API_KEY: ${MISTRAL_API_KEY}
+      SUBJECT: ${SUBJECT:-climate}
+      PULSAR_EMAIL: ${PULSAR_EMAIL}
+      PULSAR_PASSWORD: ${PULSAR_PASSWORD}
+      PULSAR_SEARCH_ID: ${PULSAR_SEARCH_ID:-201823}
+      PULSAR_FOLDER_ID: ${PULSAR_FOLDER_ID:-529}
+      PULSAR_API_KEY: ${PULSAR_API_KEY}
+      PULSAR_BASE_URL: ${PULSAR_BASE_URL:-}
+      PULSAR_TOP_N: ${PULSAR_TOP_N:-30}
+      PULSAR_DAYS_BACK: ${PULSAR_DAYS_BACK:-1}
+      PULSAR_START_DATE: ${PULSAR_START_DATE:-}
+      PULSAR_END_DATE: ${PULSAR_END_DATE:-}
+      PULSAR_RELEVANCE_MENTION_TAG_IDS: ${PULSAR_RELEVANCE_MENTION_TAG_IDS:-[]}
+      CONCURRENCY: ${CONCURRENCY:-1}
+    depends_on:
+      rrs_db:
+        condition: service_healthy
+
   console:
     build:
       context: ../

--- a/rrs/misinformation_detection/definitions.py
+++ b/rrs/misinformation_detection/definitions.py
@@ -2,7 +2,7 @@
 
 SUBJECT_DEFINITIONS: dict[str, str] = {
     "insecurity": """
-La désinformation est définie ici comme tout extrait qui porte sur les personnes étrangères, immigrées, réfugiées, demandeuses d'asile, \ 
+La désinformation est définie ici comme tout extrait qui porte sur les personnes étrangères, immigrées, réfugiées, demandeuses d'asile, \
 sans-papiers, exilées ou d'origine étrangère, qu'elles soient désignées explicitement — par leur statut administratif, \
 leur nationalité, leur religion, leur origine réelle ou supposée — ou par substitution, au moyen de formules telles que \
 « certaines populations », « quartiers sensibles », « personnes issues de », « nouveaux arrivants », « communautés », \

--- a/rrs/pulsar/fetch_weekly_themes_client.py
+++ b/rrs/pulsar/fetch_weekly_themes_client.py
@@ -101,7 +101,7 @@ _SENTIMENT_FR = {
 
 _MISINFO_MAX_CHARS = 3000  # cap per post to control token usage
 _MISINFO_MODEL_DEFAULT = "mistral-small-2603"
-_MISINFO_CONCURRENCY = 5
+_MISINFO_CONCURRENCY = int(os.getenv("CONCURRENCY", "5"))
 
 
 async def _classify_posts_async(posts: list[dict], subject: str, model: str,
@@ -202,7 +202,8 @@ def _post(endpoint: str, query: str, variables: dict, headers: dict, retries: in
         if resp.status_code == 200:
             payload = resp.json()
             if "errors" in payload:
-                raise RuntimeError(payload["errors"])
+                #logging.error(json.dumps({"query": query, "variables": variables}))
+                raise RuntimeError(json.dumps({"query": query, "variables": variables, "errors": payload["errors"]}))
             return payload
         wait = 5 * (attempt + 1)
         print(f"    got {resp.status_code}, retrying in {wait}s (attempt {attempt + 1}/{retries})...")
@@ -259,8 +260,12 @@ def get_top_themes(search_id: str, date_from_str: str, date_to_str: str,
 
 
 def build_theme(candidate: dict, search_id: str, date_from_str: str, date_to_str: str,
-                relevance_mention_tag_ids: list, headers: dict) -> dict | None:
-    """Enrich a candidate theme with AI title/sentiment/body via Pulsar API."""
+                relevance_mention_tag_ids: list, headers: dict) -> tuple[dict | None, str | None]:
+    """Enrich a candidate theme with AI title/sentiment/body via Pulsar API.
+
+    Returns (theme_data, None) on success, or (None, skip_reason) if the theme
+    could not be enriched.
+    """
     topic_labels = [t["label"] for t in candidate["topics"]]
     sresp = _post(DATA_ENDPOINT, SUMMARY_QUERY, {
         "filter": _build_filter(search_id, date_from_str, date_to_str, relevance_mention_tag_ids),
@@ -272,9 +277,13 @@ def build_theme(candidate: dict, search_id: str, date_from_str: str, date_to_str
     }, headers)
     sentences = sresp["data"]["summary"]["relevantSentences"]
     if not sentences:
-        return None
+        return None, "no representative posts"
 
-    nresp = _post(APP_ENDPOINT, NARRATIVE_QUERY, {"contents": sentences}, headers)
+    try:
+        nresp = _post(APP_ENDPOINT, NARRATIVE_QUERY, {"contents": sentences}, headers)
+    except RuntimeError as exc:
+        logging.error(f"  narrativesSummarization failed for {topic_labels}: {exc}")
+        return None, "narrativesSummarization API error"
     n = nresp["data"]["narrativesSummarization"]
 
     return {
@@ -284,7 +293,7 @@ def build_theme(candidate: dict, search_id: str, date_from_str: str, date_to_str
         "sentiment": n["sentiment"],
         "body": n["body"],
         "example_posts": sentences,
-    }
+    }, None
 
 
 def run() -> None:
@@ -309,11 +318,11 @@ def run() -> None:
 
     enriched = []
     for candidate in candidates:
-        theme_data = build_theme(
+        theme_data, skip_reason = build_theme(
             candidate, s.search_id, date_from_str, date_to_str, s.relevance_mention_tag_ids, headers
         )
         if theme_data is None:
-            print(f"  {[t['label'] for t in candidate['topics']]}: no representative posts, skipped")
+            print(f"  {[t['label'] for t in candidate['topics']]}: {skip_reason}, skipped")
             continue
         enriched.append(theme_data)
         print(f"  [{theme_data['sentiment']}] {theme_data['title']} ({theme_data['post_volume']:,} posts)")


### PR DESCRIPTION
## Summary
- Add `pulsar` service to `rrs/docker-compose.yml`, building from `rrs/Dockerfile.pulsar`
- Make `build_theme()` in `rrs/pulsar/fetch_weekly_themes_client.py` tolerate Pulsar's `narrativesSummarization` API errors per-theme instead of crashing the whole run
- Make misinfo classification concurrency configurable via `CONCURRENCY` env var (helps avoid Mistral rate limits)
- Fix stray escape sequence `SyntaxWarning` in `rrs/misinformation_detection/definitions.py`

## Test plan
- [x] `python3 -m py_compile` on changed Python files
- [x] Ran the `pulsar` service against a real Pulsar search; confirmed a theme hitting the Pulsar API error is now skipped with a log line instead of crashing the run
- [x] Confirm lowering `CONCURRENCY` avoids the Mistral 429 rate-limit errors on a full run