### PR TITLE
fix: prevent "ets" keyword false positives from matching "et"

### DIFF
--- a/quotaclimat/data_processing/mediatree/detect_keywords.py
+++ b/quotaclimat/data_processing/mediatree/detect_keywords.py
@@ -157,9 +157,14 @@ def format_word_regex(word: str) -> str:
     word = word.replace('\'', '\' ?') # case for d'eau -> d' eau
     if not word.endswith('s') and not word.endswith('x') and not word.endswith('à'):
         return word + "s?"
-    elif word.endswith('s'):
-        return word + '?'
-    elif word.endswith('x'):
+    elif word.endswith('s') or word.endswith('x'):
+        # Making the trailing letter optional only makes sense when the
+        # remaining stem is long enough to still be a meaningful word
+        # (e.g. "crises" -> "crise?s"). For short words/acronyms like "ets",
+        # dropping the last letter yields an unrelated, very common word
+        # ("et"), causing massive false positives - so keep those literal.
+        if len(word) <= 3:
+            return word
         return word + '?'
     else:
         return word


### PR DESCRIPTION
## Summary
- `format_word_regex` made the trailing letter of any keyword ending in `s`/`x` optional, assuming the dictionary word was a regular plural (e.g. `crises` -> `crise?s`).
- For the short acronym `ets`, this produced the regex `ets?`, which also matched the common French word `et`, flooding detections with false positives (and defaulting their timestamp to 0 when the per-chunk subtitle lookup couldn't relocate a match).
- Short (<=3 char) words ending in `s`/`x` are now kept literal instead of getting the optional-trailing-letter treatment.

## Test plan
- [x] `pytest test/sitemap/test_detect_keywords.py -k "format_word_regex or is_word_in_sentence_fr"` passes

