### PR TITLE
fix: keyset pagination for keyword update + route French detection by language

### DIFF
--- a/quotaclimat/data_processing/mediatree/detect_keywords.py
+++ b/quotaclimat/data_processing/mediatree/detect_keywords.py
@@ -376,7 +376,7 @@ def get_keyword_matching_json(keyword_dict: List[dict], country=FRANCE) -> dict:
 
 # def get_words_in_sentence(automaton: ahocorasick.Automaton, keywords_dict: Dict[str, str], text: str, country: CountryMediaTree=FRANCE) -> Set[str]:
 def get_words_in_sentence(keywords_dict: Dict[str, str], text: str, country: CountryMediaTree=FRANCE) -> Set[str]:
-    if country.code=='fra':
+    if country.language=='french':
         logging.info("Using regex for france")
         keywords_tuple = tuple(kw["keyword"] for kw in keywords_dict)
         compiled_patterns = _compile_fr_keyword_patterns(keywords_tuple)

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -10,7 +10,7 @@ from quotaclimat.data_processing.mediatree.detect_keywords import get_themes_key
 from typing import List
 from quotaclimat.data_processing.mediatree.stop_word.main import get_stop_words
 from quotaclimat.data_processing.mediatree.channel_program import get_programs, get_a_program_with_start_timestamp
-from sqlalchemy import func, select, and_, or_
+from sqlalchemy import func, select, and_, or_, tuple_
 from quotaclimat.data_processing.mediatree.i8n.country import FRANCE, get_channel_title_for_name
 
 def get_keyword_else_context(stop_word_object: Stop_Word):
@@ -98,16 +98,16 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
 
     logging.info(f"Updating {country.name} - {total_updates} saved keywords from {start_date} date to {end_date} for channel {channel} - batch size {batch_size} - totals rows")
 
-    last_id = 0
+    cursor = None
     processed = 0
     while True:
-        current_batch_saved_keywords = get_keywords_columns(session, last_id, batch_size, start_date, end_date, channel, \
+        current_batch_saved_keywords = get_keywords_columns(session, cursor, batch_size, start_date, end_date, channel, \
                                                             empty_program_only, keywords_to_includes=top_keyword_of_stop_words, \
                                                             biodiversity_only=biodiversity_only, country=country)
         if not current_batch_saved_keywords:
             break
 
-        logging.info(f"Updating {len(current_batch_saved_keywords)} elements after id {last_id} - batch size {batch_size} - total {total_updates}")
+        logging.info(f"Updating {len(current_batch_saved_keywords)} elements after cursor {cursor} - batch size {batch_size} - total {total_updates}")
         for keyword_id, plaintext, keywords_with_timestamp, number_of_keywords, start, srt, theme, channel_name, channel_title in current_batch_saved_keywords:
             if channel_title is None:
                 logging.warning(f"channel_title none, set it using channel_name {channel_name}")
@@ -209,21 +209,24 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
                 except Exception as err:
                     logging.error(f"update_program_only - continuing loop but met error : {err}")
                     continue
-        last_id = current_batch_saved_keywords[-1][0]
+        last_row = current_batch_saved_keywords[-1]
+        cursor = (last_row[4], last_row[7], last_row[1], last_row[0])  # (start, channel_name, plaintext, id)
         processed += len(current_batch_saved_keywords)
-        logging.info(f"bulk update done {processed} out of {total_updates} - last_id {last_id}")
+        logging.info(f"bulk update done {processed} out of {total_updates} - cursor {cursor}")
         session.commit()
 
     logging.info("updated all keywords")
 
 
-def get_keywords_columns(session: Session, last_id: int = 0, batch_size: int = 50000, start_date: str = "2023-04-01", end_date: str = "2023-04-30",\
+def get_keywords_columns(session: Session, cursor: tuple = None, batch_size: int = 50000, start_date: str = "2023-04-01", end_date: str = "2023-04-30",\
                          channel: str = "", empty_program_only: bool = False, keywords_to_includes: list[str] = [], \
                          biodiversity_only = False, country = FRANCE) -> list:
-    # Keyset pagination (id > last_id) instead of OFFSET: rows can be deleted mid-run
-    # (see update_keyword_row) when a row's themes recompute to empty, which shifts
-    # OFFSET-based pages and silently skips rows straddling the boundary.
-    logging.info(f"Getting {batch_size} elements after id {last_id} with timezone {country.timezone}")
+    # Keyset pagination ((start, channel_name, plaintext, id) > cursor) instead of OFFSET:
+    # rows can be deleted mid-run (see update_keyword_row) when a row's themes recompute to
+    # empty, which shifts OFFSET-based pages and silently skips rows straddling the boundary.
+    # id is included only to break ties deterministically (it is unique), keeping the original
+    # chronological ordering intact.
+    logging.info(f"Getting {batch_size} elements after cursor {cursor} with timezone {country.timezone}")
     query = session.query(
             Keywords.id,
             Keywords.plaintext,
@@ -240,9 +243,13 @@ def get_keywords_columns(session: Session, last_id: int = 0, batch_size: int = 5
             func.date(Keywords.start) <= end_date,
             Keywords.country == country.name,
             Keywords.channel_name.in_(country.channels),
-            Keywords.id > last_id,
         )
-    ).order_by(Keywords.id)
+    ).order_by(Keywords.start, Keywords.channel_name, Keywords.plaintext, Keywords.id)
+
+    if cursor is not None:
+        query = query.filter(
+            tuple_(Keywords.start, Keywords.channel_name, Keywords.plaintext, Keywords.id) > cursor
+        )
 
     if channel != "":
         query = query.filter(Keywords.channel_name == channel)

--- a/quotaclimat/data_processing/mediatree/update_pg_keywords.py
+++ b/quotaclimat/data_processing/mediatree/update_pg_keywords.py
@@ -97,12 +97,17 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
         batch_size = total_updates
 
     logging.info(f"Updating {country.name} - {total_updates} saved keywords from {start_date} date to {end_date} for channel {channel} - batch size {batch_size} - totals rows")
-    
-    for i in range(0, total_updates, batch_size):
-        current_batch_saved_keywords = get_keywords_columns(session, i, batch_size, start_date, end_date, channel, \
+
+    last_id = 0
+    processed = 0
+    while True:
+        current_batch_saved_keywords = get_keywords_columns(session, last_id, batch_size, start_date, end_date, channel, \
                                                             empty_program_only, keywords_to_includes=top_keyword_of_stop_words, \
                                                             biodiversity_only=biodiversity_only, country=country)
-        logging.info(f"Updating {len(current_batch_saved_keywords)} elements from {i} offsets - batch size {batch_size} - until offset {total_updates}")
+        if not current_batch_saved_keywords:
+            break
+
+        logging.info(f"Updating {len(current_batch_saved_keywords)} elements after id {last_id} - batch size {batch_size} - total {total_updates}")
         for keyword_id, plaintext, keywords_with_timestamp, number_of_keywords, start, srt, theme, channel_name, channel_title in current_batch_saved_keywords:
             if channel_title is None:
                 logging.warning(f"channel_title none, set it using channel_name {channel_name}")
@@ -204,16 +209,21 @@ def update_keywords(session: Session, batch_size: int = 50000, start_date : str 
                 except Exception as err:
                     logging.error(f"update_program_only - continuing loop but met error : {err}")
                     continue
-        logging.info(f"bulk update done {i} out of {total_updates} - (max offset {total_updates})")
+        last_id = current_batch_saved_keywords[-1][0]
+        processed += len(current_batch_saved_keywords)
+        logging.info(f"bulk update done {processed} out of {total_updates} - last_id {last_id}")
         session.commit()
 
     logging.info("updated all keywords")
 
 
-def get_keywords_columns(session: Session, offset: int = 0, batch_size: int = 50000, start_date: str = "2023-04-01", end_date: str = "2023-04-30",\
+def get_keywords_columns(session: Session, last_id: int = 0, batch_size: int = 50000, start_date: str = "2023-04-01", end_date: str = "2023-04-30",\
                          channel: str = "", empty_program_only: bool = False, keywords_to_includes: list[str] = [], \
                          biodiversity_only = False, country = FRANCE) -> list:
-    logging.info(f"Getting {batch_size} elements from offset {offset} with timezone {country.timezone}")
+    # Keyset pagination (id > last_id) instead of OFFSET: rows can be deleted mid-run
+    # (see update_keyword_row) when a row's themes recompute to empty, which shifts
+    # OFFSET-based pages and silently skips rows straddling the boundary.
+    logging.info(f"Getting {batch_size} elements after id {last_id} with timezone {country.timezone}")
     query = session.query(
             Keywords.id,
             Keywords.plaintext,
@@ -226,12 +236,13 @@ def get_keywords_columns(session: Session, offset: int = 0, batch_size: int = 50
             Keywords.channel_title,
         ).filter(
         and_(
-            func.date(Keywords.start) >= start_date, 
+            func.date(Keywords.start) >= start_date,
             func.date(Keywords.start) <= end_date,
             Keywords.country == country.name,
             Keywords.channel_name.in_(country.channels),
+            Keywords.id > last_id,
         )
-    ).order_by(Keywords.start, Keywords.channel_name, Keywords.plaintext)
+    ).order_by(Keywords.id)
 
     if channel != "":
         query = query.filter(Keywords.channel_name == channel)
@@ -260,9 +271,7 @@ def get_keywords_columns(session: Session, offset: int = 0, batch_size: int = 50
             or_(*[Keywords.plaintext.ilike(f"%{word}%") for word in keywords_to_includes])
         )
 
-    return query.offset(offset) \
-        .limit(batch_size) \
-        .all()
+    return query.limit(batch_size).all()
 
 def get_total_count_saved_keywords(session: Session, start_date : str, end_date : str, channel: str, empty_program_only: bool,\
                                     keywords_to_includes= [], biodiversity_only = False, country= FRANCE) -> int:


### PR DESCRIPTION
## Summary
- `update_pg_keywords.py`: replace OFFSET-based batch pagination with keyset pagination (`id > last_id`). Deleting a row mid-run (when its themes recompute to empty after a dictionary change) shrinks the table and shifts subsequent OFFSET pages, silently skipping rows that straddle the batch boundary — this is why a recent `UPDATE=true` run for Belgium left some August rows with stale "ets" detections.
- `detect_keywords.py`: route `get_words_in_sentence` on `country.language` instead of `country.code=='fra'`, so Belgium (French-language) uses the regex path (with the short-acronym guard from #631) instead of the generic i18n lemma-matching path, where spaCy's French lemmatizer was collapsing short words like `"ets"` onto unrelated common lemmas (e.g. `"et"`), causing false-positive detections.

## Test plan
- [ ] Run the test suite (`docker compose up test`)
- [ ] Re-run the `UPDATE=true` job for Belgium scoped to `START_DATE_UPDATE=2026-08-13`/`END_DATE=2026-09-01` and confirm no rows remain with stale `keywords_with_timestamp` entries after this fix
- [ ] Spot-check that French/Belgium detection results are unchanged for non-"ets" keywords after switching the routing condition